### PR TITLE
Update consul flavour to support single server, 3 server cluster, 5 server cluster

### DIFF
--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.0.2
+
+* Accepts BOOTSTRAP=1 for single server; and BOOTSTRAP=3 or BOOTSTRAP=5 provided correct PEERS variable set
+
+---
+
 2.0.1
 
 * Fixed wrong "BOOTSTRAP"-escaping

--- a/consul/README.md
+++ b/consul/README.md
@@ -22,6 +22,10 @@ Together with the [nomad-server](https://potluck.honeyguide.net/blog/nomad-serve
 
 The BOOTSTRAP parameter defines the expected number of cluster nodes, it defaults to 1 (no cluster) if it is not set.
 
+For 3 and 5 node clusters the other peers must be passed in via the PEERS variable in the following format.
+
+```-E IP=10.0.0.1 -E PEERS='"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"'```
+
 # Usage
 
 You can connect to the dashboard on port 8500 of your jail IP address.

--- a/consul/consul.sh
+++ b/consul/consul.sh
@@ -169,7 +169,7 @@ then
 fi
 if [ -z \${BOOTSTRAP+x} ];
 then
-    echo 'BOOTSTRAP is unset - see documentation how to configure this flavour'
+    echo 'BOOTSTRAP is unset - see documentation how to configure this flavour, defaulting to 1'
     BOOTSTRAP=1
 fi
 

--- a/postgresql/CHANGELOG.md
+++ b/postgresql/CHANGELOG.md
@@ -1,0 +1,15 @@
+1.0.2
+
+* Working cluster version 
+
+---
+
+1.0.1
+
+* First bash at Postgres single server image
+
+---
+
+1.0.0
+
+* Initial commit

--- a/postgresql/Readme.md
+++ b/postgresql/Readme.md
@@ -1,0 +1,23 @@
+# Overview
+
+This is a patroni postgresql jail that can be started with ```pot``` but it can also be deployed via ```nomad```.
+
+It requires 5 ```consul-cluster``` servers running and the IPs passed in as part of the ```pot env``` setup.
+
+For more details about ```nomad``` images, see [about potluck](https://potluck.honeyguide.net/micro/about-potluck/).
+
+The jail exposes these parameters that can either be set via the environment or by setting the ```cook```parameters (the latter either via ```nomad```, see example below, or by editing the downloaded jails ```pot.conf``` file):
+
+| Environment | Content    | Unfilled column    |
+| :---------- | :----------------: | :-----------|
+| DATACENTER  | - datacentre name                 | ...  |
+| NODENAME    | - unique name for node, each patroni-postgresql instance must have unique name                 | ...       |
+| MYIP        | - IP address of this node                 | ...                  |
+| SERVICETAG  | - service tag for node (master/replica/standby-leader)     | ...                  |
+| CONSULSERVERONE | - IP of first consul server in a 5 node cluster                 | ...             |
+| CONSULSERVERTWO | - IP of next consul server in a 5 node cluster                 | ...             |
+| CONSULSERVERTHREE | - IP of next consul server in a 5 node cluster                 | ...             |
+| CONSULSERVERFOUR | - IP of next consul server in a 5 node cluster                 | ...             |
+| CONSULSERVERFIVE | - IP of next consul server in a 5 node cluster                 | ...             |
+| ADMPASS     | - admin password                 | ...                  |
+| KEKPASS     | - postgresql super user password                 | ...                  |

--- a/postgresql/postgresql
+++ b/postgresql/postgresql
@@ -1,0 +1,2 @@
+copy-in -s /usr/local/etc/pot/flavours/postgresql.d/patroni.rc -d /root/patroni.rc
+copy-in -s /usr/local/etc/pot/flavours/postgresql.d/patroni.yml -d /root/patroni.yml

--- a/postgresql/postgresql+4
+++ b/postgresql/postgresql+4
@@ -1,0 +1,1 @@
+set-cmd -c "/usr/local/bin/cook"

--- a/postgresql/postgresql.d/patroni.rc
+++ b/postgresql/postgresql.d/patroni.rc
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+# PROVIDE: patroni
+
+. /etc/rc.subr
+
+name="patroni"
+rcvar=patroni_enable
+
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
+reload_cmd="${name}_reload"
+list_cmd="${name}_list"
+history_cmd="${name}_history"
+extra_commands="list history"
+
+
+load_rc_config $name
+load_rc_config postgresql # load postgres configuration for user and group permission
+: ${patroni_enable:=no}
+: ${patroni_config:="/usr/local/etc/patroni/patroni.yml"}
+: ${patroni_pid:="/var/run/patroni.pid"}
+: ${patroni_cmd:="/usr/local/bin/patroni"}
+: ${patroni_ctl:="/usr/local/bin/patronictl"}
+: ${postgresql_user:="postgres"}
+: ${su_cmd:="/usr/bin/su"}
+: ${daemon_cmd:="/usr/sbin/daemon"}
+: ${kill_cmd:="/bin/kill"}
+: ${cat_cmd:="/bin/cat"}
+
+
+patroni_start()
+{
+  # -S -> syslog output
+  # -R 10 restart after 10s when patroni denied
+  # -P daemon pidfile
+  # -T syslog Tag
+
+  ${daemon_cmd} -S -R 10 -u ${postgresql_user} -P ${patroni_pid} -T ${name} ${patroni_cmd} ${patroni_config}
+}
+
+patroni_stop()
+{
+	${kill_cmd} `${cat_cmd} ${patroni_pid}`
+}
+
+patroni_reload()
+{
+	${patroni_ctl} -c ${patroni_config} reload
+}
+
+patroni_list()
+{
+	${patroni_ctl} -c ${patroni_config} list
+}
+
+patroni_history()
+{
+	${patroni_ctl} -c ${patroni_config} history
+}
+
+run_rc_command "$1"

--- a/postgresql/postgresql.d/patroni.yml
+++ b/postgresql/postgresql.d/patroni.yml
@@ -1,0 +1,53 @@
+scope: patronipsql
+#namespace: /service/
+name: MYNAME
+
+restapi:
+  listen: MYIP:8008
+  connect_address: MYIP:8008
+
+consul:
+  host: CONSULIP:8500 # local IP
+  service_tags: SERVICETAG #master/replica/standby-leader
+  register_service: true
+  service_check_interval: 30
+
+bootstrap:
+  dcs:
+    ttl: 30
+    loop_wait: 10
+    retry_timeout: 10
+    maximum_lag_on_failover: 1048576
+    postgresql:
+      use_pg_rewind: true
+      parameters:
+  initdb:  # Note: It needs to be a list (some options need values, others are switches)
+  - encoding: UTF8
+  - data-checksums
+  pg_hba:  # Add following lines to pg_hba.conf after running 'initdb'
+  - host replication replicator 0.0.0.0/0 md5
+  - host all all 0.0.0.0/0 md5
+  users:
+    admin:
+      password: ADMPASS
+      options:
+        - createrole
+        - createdb
+
+postgresql:
+  listen: MYIP:5432
+  connect_address: MYIP:5432
+  data_dir: /var/db/postgres
+  pgpass: /tmp/pgpass0
+  authentication:
+    replication:
+      username: replicator
+      password: rep-pass
+    superuser:
+      username: postgres
+      password: KEKPASS
+    rewind:  # Has no effect on postgres 10 and lower
+      username: rewind_user
+      password: rewind_password
+  parameters:
+    unix_socket_directories: '.'

--- a/postgresql/postgresql.sh
+++ b/postgresql/postgresql.sh
@@ -1,0 +1,422 @@
+#!/bin/sh
+
+# Based on POTLUCK TEMPLATE v3.0
+# Altered by Michael Gmelin
+#
+# EDIT THE FOLLOWING FOR NEW FLAVOUR:
+# 1. RUNS_IN_NOMAD - true or false
+# 2. If RUNS_IN_NOMAD is false, can delete the <flavour>+4 file, else
+#    make sure pot create command doesn't include it
+# 3. Create a matching <flavour> file with this <flavour>.sh file that
+#    contains the copy-in commands for the config files from <flavour>.d/
+#    Remember that the package directories don't exist yet, so likely copy
+#    to /root
+# 4. Adjust package installation between BEGIN & END PACKAGE SETUP
+# 5. Adjust jail configuration script generation between BEGIN & END COOK
+#    Configure the config files that have been copied in where necessary
+
+# Set this to true if this jail flavour is to be created as a nomad (i.e. blocking) jail.
+# You can then query it in the cook script generation below and the script is installed
+# appropriately at the end of this script
+RUNS_IN_NOMAD=false
+
+# set the cook log path/filename
+COOKLOG=/var/log/cook.log
+
+# check if cooklog exists, create it if not
+if [ ! -e $COOKLOG ]
+then
+    echo "Creating $COOKLOG" | tee -a $COOKLOG
+else
+    echo "WARNING $COOKLOG already exists"  | tee -a $COOKLOG
+fi
+date >> $COOKLOG
+
+# -------------------- COMMON ---------------
+
+STEPCOUNT=0
+step() {
+  STEPCOUNT=$(expr "$STEPCOUNT" + 1)
+  STEP="$@"
+  echo "Step $STEPCOUNT: $STEP" | tee -a $COOKLOG
+}
+
+exit_ok() {
+  trap - EXIT
+  exit 0
+}
+
+FAILED=" failed"
+exit_error() {
+  STEP="$@"
+  FAILED=""
+  exit 1
+}
+
+set -e
+trap 'echo ERROR: $STEP$FAILED | (>&2 tee -a $COOKLOG)' EXIT
+
+# -------------- BEGIN PACKAGE SETUP -------------
+
+step "Bootstrap package repo"
+mkdir -p /usr/local/etc/pkg/repos
+#echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
+echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
+  >/usr/local/etc/pkg/repos/FreeBSD.conf
+ASSUME_ALWAYS_YES=yes pkg bootstrap
+
+step "Touch /etc/rc.conf"
+touch /etc/rc.conf
+
+# this is important, otherwise running /etc/rc from cook will
+# overwrite the IP address set in tinirc
+step "Remove ifconfig_epair0b from config"
+sysrc -cq ifconfig_epair0b && sysrc -x ifconfig_epair0b || true
+
+step "Disable sendmail"
+service sendmail disable
+
+step "Create /usr/local/etc/rc.d"
+mkdir -p /usr/local/etc/rc.d
+
+step "Update package repository"
+pkg update -f
+
+step "Install package sudo"
+pkg install -y sudo
+
+step "Install package openssl"
+pkg install -y openssl
+
+step "Install package vault"
+pkg install -y vault
+
+step "Install package consul"
+pkg install -y consul
+
+step "Install package postgresql-client"
+pkg install -y postgresql12-client
+
+step "Install package postgresql-server"
+pkg install -y postgresql12-server
+
+step "Install package python37"
+pkg install -y python37
+
+step "Install package python3-pip"
+pkg install -y py37-pip
+
+step "Install package python-consul2"
+pkg install -y py37-python-consul2
+
+step "Install package psycopg2"
+pkg install -y py37-psycopg2
+#
+# pip MUST ONLY be used:
+# * With the --user flag, OR
+# * To install or manage Python packages in virtual environments
+# using -prefix here to force install in /usr/local/bin
+
+step "Install pip package patroni"
+pip install patroni --prefix="/usr/local"
+#
+## WARNING: The scripts patroni, patroni_aws, patroni_raft_controller,
+## patroni_wale_restore and patronictl are installed in
+## '--prefix=/usr/local/bin' which is not on PATH.
+## Consider adding this directory to PATH or, if you prefer to suppress
+## this warning, use --no-warn-script-location.
+
+step "Clean package installation"
+pkg clean -y
+
+# -------------- END PACKAGE SETUP -------------
+#
+# Create configurations
+#
+
+#
+# Now generate the run command script "cook"
+# It configures the system on the first run by creating the config file(s)
+# On subsequent runs, it only starts sleeps (if nomad-jail) or simply exits
+#
+
+# clear any old cook runtime file
+step "Remove pre-existing cook script (if any)"
+rm -f /usr/local/bin/cook
+
+# this runs when image boots
+# ----------------- BEGIN COOK ------------------
+
+step "Create cook script"
+echo "#!/bin/sh
+RUNS_IN_NOMAD=$RUNS_IN_NOMAD
+# declare this again for the pot image, might work carrying variable through like
+# with above
+COOKLOG=/var/log/cook.log
+
+# No need to change this, just ensures configuration is done only once
+if [ -e /usr/local/etc/pot-is-seasoned ]
+then
+    # If this pot flavour is blocking (i.e. it should not return),
+    # we block indefinitely
+    if [ \"\$RUNS_IN_NOMAD\" = \"true\" ]
+    then
+        /bin/sh /etc/rc
+        tail -f /dev/null
+    fi
+    exit 0
+fi
+
+# ADJUST THIS: STOP SERVICES AS NEEDED BEFORE CONFIGURATION
+#
+
+# stop consul agent
+/usr/local/etc/rc.d/consul stop || true
+
+# No need to adjust this:
+# If this pot flavour is not blocking, we need to read the environment first from /tmp/environment.sh
+# where pot is storing it in this case
+if [ -e /tmp/environment.sh ]
+then
+    . /tmp/environment.sh
+fi
+#
+# ADJUST THIS BY CHECKING FOR ALL VARIABLES YOUR FLAVOUR NEEDS:
+# Check config variables are set
+#
+if [ -z \${DATACENTER+x} ];
+then
+    echo 'DATACENTER is unset - see documentation how to configure this flavour'
+    exit 1
+fi
+if [ -z \${CONSULSERVERONE+x} ];
+then
+    echo 'CONSULSERVERONE is unset - see documentation how to configure this flavour'
+    exit 1
+fi
+if [ -z \${CONSULSERVERTWO+x} ];
+then
+    echo 'CONSULSERVERTWO is unset - see documentation how to configure this flavour'
+    exit 1
+fi
+if [ -z \${CONSULSERVERTHREE+x} ];
+then
+    echo 'CONSULSERVERTHREE is unset - see documentation how to configure this flavour'
+    exit 1
+fi
+if [ -z \${CONSULSERVERFOUR+x} ];
+then
+    echo 'CONSULSERVERFOUR is unset - see documentation how to configure this flavour'
+    exit 1
+fi
+if [ -z \${CONSULSERVERFIVE+x} ];
+then
+    echo 'CONSULSERVERFIVE is unset - see documentation how to configure this flavour'
+    exit 1
+fi
+if [ -z \${NODENAME+x} ];
+then
+    echo 'The unique option NODENAME is unset - see documentation how to configure this flavour'
+    exit 1
+fi
+if [ -z \${MYIP+x} ];
+then
+    echo 'MYIP is unset - see documentation how to configure this flavour'
+    MYIP=\"127.0.0.1\"
+fi
+if [ -z \${SERVICETAG+x} ];
+then
+    echo 'SERVICETAG is unset - see documentation how to configure this flavour'
+    SERVICETAG=master
+fi
+if [ -z \${ADMPASS+x} ];
+then
+    echo 'ADMPASS is unset - see documentation how to configure this flavour'
+    ADMPASS=admin
+fi
+if [ -z \${KEKPASS+x} ];
+then
+    echo 'KEKPASS is unset - see documentation how to configure this flavour'
+    KEKPASS=kekpass
+fi
+
+# make consul configuration directory and set permissions
+mkdir -p /usr/local/etc/consul.d
+chmod 750 /usr/local/etc/consul.d
+
+# Create the consul agent config file with imported variables
+echo \"{
+ \\\"advertise_addr\\\": \\\"\$MYIP\\\",
+ \\\"datacenter\\\": \\\"\$DATACENTER\\\",
+ \\\"node_name\\\": \\\"\$NODENAME\\\",
+ \\\"data_dir\\\":  \\\"/var/db/consul\\\",
+ \\\"dns_config\\\": {
+  \\\"a_record_limit\\\": 3,
+  \\\"enable_truncate\\\": true
+ },
+ \\\"log_file\\\": \\\"/var/log/consul/\\\",
+ \\\"log_level\\\": \\\"WARN\\\",
+ \\\"start_join\\\": [
+  \\\"\$CONSULSERVERONE\\\",
+  \\\"\$CONSULSERVERTWO\\\",
+  \\\"\$CONSULSERVERTHREE\\\",
+  \\\"\$CONSULSERVERFOUR\\\",
+  \\\"\$CONSULSERVERFIVE\\\"
+ ]
+}\" > /usr/local/etc/consul.d/agent.json
+
+# set owner and perms on agent.json
+chown consul:wheel /usr/local/etc/consul.d/agent.json
+chmod 640 /usr/local/etc/consul.d/agent.json
+
+# enable consul
+sysrc consul_enable=\"YES\"
+
+# set load parameter for consul config
+sysrc consul_args=\"-config-file=/usr/local/etc/consul.d/agent.json\"
+#sysrc consul_datadir=\"/var/db/consul\"
+
+# Workaround for bug in rc.d/consul script:
+sysrc consul_group=\"wheel\"
+
+# setup consul logs, might be redundant if not specified in agent.json above
+mkdir -p /var/log/consul
+touch /var/log/consul/consul.log
+chown -R consul:wheel /var/log/consul
+
+# add the consul user to the wheel group, this seems to be required for
+# consul to start on this instance. May need to figure out why. 
+# I'm not entirely sure this is the correct way to do it
+/usr/sbin/pw usermod consul -G wheel
+
+# set patroni variables in /root/patroni.yml before copy
+if [ -f /root/patroni.yml ]; then
+    # steps go here for replacing MYIP with this node IP and
+    # MYNAME with var NODENAME 
+    # CONSULIP with var CONSULSERVERONE
+    # SERVICETAG with master/replica/standby-leader
+    # KEKPASS with master postgresql password
+
+    # replace MYNAME with imported variable NODENAME which must be unique
+    /usr/bin/sed -i .orig \"/MYNAME/s/MYNAME/\$NODENAME/g\" /root/patroni.yml
+
+    # replace MYIP with imported variable MYIP
+    /usr/bin/sed -i .orig \"/MYIP/s/MYIP/\$MYIP/g\" /root/patroni.yml
+
+    # replace SERVICETAG with imported variable SERVICETAG
+    /usr/bin/sed -i .orig \"/SERVICETAG/s/SERVICETAG/\$SERVICETAG/g\" /root/patroni.yml
+
+    # replace CONSULIP with imported variable MYIP, as using local consul agent
+    /usr/bin/sed -i .orig \"/CONSULIP/s/CONSULIP/\$MYIP/g\" /root/patroni.yml
+
+    # replace ADMPASS with imported variable ADMPASS
+    /usr/bin/sed -i .orig \"/ADMPASS/s/ADMPASS/\$ADMPASS/g\" /root/patroni.yml
+
+    # replace KEKPASS with imported variable KEKPASS
+    /usr/bin/sed -i .orig \"/KEKPASS/s/KEKPASS/\$KEKPASS/g\" /root/patroni.yml
+fi
+
+# create /usr/local/etc/patroni/
+mkdir -p /usr/local/etc/patroni/
+
+# copy the file to startup location
+cp /root/patroni.yml /usr/local/etc/patroni/patroni.yml
+
+# copy patroni startup script to /usr/local/etc/rc.d/
+cp /root/patroni.rc /usr/local/etc/rc.d/patroni
+
+# enable postgresql
+sysrc postgresql_enable=\"YES\"
+
+# enable patroni
+sysrc patroni_enable=\"YES\"
+
+# end postgresql
+
+# ADJUST THIS: START THE SERVICES AGAIN AFTER CONFIGURATION
+
+# start consul agent
+/usr/local/etc/rc.d/consul start
+
+# start patroni, which should start postgresql
+/usr/local/etc/rc.d/patroni start
+
+#
+# Do not touch this:
+touch /usr/local/etc/pot-is-seasoned
+
+# If this pot flavour is blocking (i.e. it should not return), there is no /tmp/environment.sh
+# created by pot and we now after configuration block indefinitely
+if [ \"\$RUNS_IN_NOMAD\" = \"true\" ]
+then
+    /bin/sh /etc/rc
+    tail -f /dev/null
+fi
+" > /usr/local/bin/cook
+
+# ----------------- END COOK ------------------
+
+
+# ---------- NO NEED TO EDIT BELOW ------------
+
+step "Make cook script executable"
+if [ -e /usr/local/bin/cook ]
+then
+    echo "setting executable bit on /usr/local/bin/cook" | tee -a $COOKLOG
+    chmod u+x /usr/local/bin/cook
+else
+    exit_error "there is no /usr/local/bin/cook to make executable"
+fi
+
+#
+# There are two ways of running a pot jail: "Normal", non-blocking mode and
+# "Nomad", i.e. blocking mode (the pot start command does not return until
+# the jail is stopped).
+# For the normal mode, we create a /usr/local/etc/rc.d script that starts
+# the "cook" script generated above each time, for the "Nomad" mode, the cook
+# script is started by pot (configuration through flavour file), therefore
+# we do not need to do anything here.
+#
+
+# Create rc.d script for "normal" mode:
+step "Create rc.d script to start cook"
+echo "creating rc.d script to start cook" | tee -a $COOKLOG
+
+echo "#!/bin/sh
+#
+# PROVIDE: cook
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+#
+. /etc/rc.subr
+name=\"cook\"
+rcvar=\"cook_enable\"
+load_rc_config \$name
+: \${cook_enable:=\"NO\"}
+: \${cook_env:=\"\"}
+command=\"/usr/local/bin/cook\"
+command_args=\"\"
+run_rc_command \"\$1\"
+" > /usr/local/etc/rc.d/cook
+
+step "Make rc.d script to start cook executable"
+if [ -e /usr/local/etc/rc.d/cook ]
+then
+  echo "Setting executable bit on cook rc file" | tee -a $COOKLOG
+  chmod u+x /usr/local/etc/rc.d/cook
+else
+  exit_error "/usr/local/etc/rc.d/cook does not exist"
+fi
+
+if [ "$RUNS_IN_NOMAD" != "true" ]
+then
+  step "Enable cook service"
+  # This is a non-nomad (non-blocking) jail, so we need to make sure the script
+  # gets started when the jail is started:
+  # Otherwise, /usr/local/bin/cook will be set as start script by the pot flavour
+  echo "enabling cook" | tee -a $COOKLOG
+  service cook enable
+fi
+
+# -------------------- DONE ---------------
+exit_ok


### PR DESCRIPTION
Consul flavour script updated to allow for `BOOTSTRAP=1` for a single server, `BOOTSTRAP=3` for a 3 node cluster, and `BOOTSTRAP=5` for a 5 node cluster.

For 3 and 5 node clusters the other peers must be passed in via the `PEERS` variable in the following format.
```
-E IP=10.0.0.1 -E PEERS='"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"' 
```