### PR TITLE
fixing up error in consul agent.json with trailing comma

### DIFF
--- a/postgresql-patroni/CHANGELOG.md
+++ b/postgresql-patroni/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.0.1
+
+* Fixing up minor type with trailing comma in consul agent.json setup
+
+---
+
 2.0
 
 * Several updates including new postgresql version, better parameter variables

--- a/postgresql-patroni/postgresql-patroni.sh
+++ b/postgresql-patroni/postgresql-patroni.sh
@@ -235,7 +235,7 @@ echo \"{
  },
  \\\"log_file\\\": \\\"/var/log/consul/\\\",
  \\\"log_level\\\": \\\"WARN\\\",
- \\\"start_join\\\": [ \$CONSULSERVERS ],
+ \\\"start_join\\\": [ \$CONSULSERVERS ]
 }\" > /usr/local/etc/consul.d/agent.json
 
 # set owner and perms on agent.json


### PR DESCRIPTION
Testing revealed a trailing comma in the consul agent.json setup. Removed.