### PR TITLE
enabling gossip encryption with a key

### DIFF
--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.0.6
+
+* Setup consul to use a default gossip encryption key
+
+---
+
 2.0.5
 
 * Inclusion of consul-template and vault-agentl.hcl

--- a/consul/README.md
+++ b/consul/README.md
@@ -18,7 +18,7 @@ Together with the [nomad-server](https://potluck.honeyguide.net/blog/nomad-serve
   ```pot export-ports -p <jailname> -e 8500:8500```   
   Note: If you want to use the ```consul``` DNS service, you either need to expose the DNS UDP port like for the [Jitsi Meet Nomad potluck image](https://potluck.honeyguide.net/blog/jitsi-meet-nomad/) or you need to clone the jail and assign a host IP address (like for the [Nomad Server image](https://potluck.honeyguide.net/blog/nomad-server/)).
 * Adjust to your environment:    
-```sudo pot set-env -p <jailname> -E DATACENTER=<datacentername> -E NODENAME=<consul-nodename> -E IP=<IP address of this consul node> [-E BOOTSTRAP=<1|3|5>] -E VAULT=<IP address of a vault server>```
+```sudo pot set-env -p <jailname> -E DATACENTER=<datacentername> -E NODENAME=<consul-nodename> -E IP=<IP address of this consul node> [-E BOOTSTRAP=<1|3|5>] -E VAULT=<IP address of a vault server> -E GOSSIPKEY=<32 byte Base64 consul keygen key>```
 
 The BOOTSTRAP parameter defines the expected number of cluster nodes, it defaults to 1 (no cluster) if it is not set.
 
@@ -27,6 +27,8 @@ For 3 and 5 node clusters the other peers must be passed in via the PEERS variab
 ```-E IP=10.0.0.1 -E PEERS='"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"'```
 
 The VAULT parameter is for a ```vault``` server that may not exist yet, so defaults to empty variable. 
+
+The GOSSIPKEY parameter is to enable custom gossip encryption and defaults to a standard key. Do not use this key in production.
 
 # Usage
 

--- a/consul/consul.sh
+++ b/consul/consul.sh
@@ -179,6 +179,13 @@ then
     echo 'VAULT is unset - see documentation how to configure this flavour, defaulting to null'
     VAULT='\"\"'
 fi
+# GOSSIPKEY is a 32 byte, Base64 encoded key generated with consul keygen
+# you must generate this key on a live consul server
+if [ -z \${GOSSIPKEY+x} ];
+then
+    echo 'GOSSIPKEY is unset - see documentation how to configure this flavour, defaulting to preset encrypt key. Do not use this in production!'
+    GOSSIPKEY='\"BY+vavBUSEmNzmxxS3k3bmVFn1giS4uEudc774nBhIw=\"'
+fi
 
 # ADJUST THIS BELOW: NOW ALL THE CONFIGURATION FILES NEED TO BE CREATED:
 # Don't forget to double(!)-escape quotes and dollar signs in the config files
@@ -210,8 +217,9 @@ case \$BOOTSTRAP in
      \\\"translate_wan_addrs\\\": true,
      \\\"ui\\\": true,
      \\\"server\\\": true,
+     \\\"encrypt\\\": \$GOSSIPKEY,
      \\\"bootstrap_expect\\\": \$BOOTSTRAP
-  }\" > /usr/local/etc/consul.d/agent.json
+}\" > /usr/local/etc/consul.d/agent.json
 
      echo \"consul_args=\\\"-advertise \$IP\\\"\" >> /etc/rc.conf
      ;;
@@ -233,10 +241,11 @@ case \$BOOTSTRAP in
      \\\"translate_wan_addrs\\\": true,
      \\\"ui\\\": true,
      \\\"server\\\": true,
+     \\\"encrypt\\\": \$GOSSIPKEY,
      \\\"bootstrap_expect\\\": \$BOOTSTRAP,
      \\\"rejoin_after_leave\\\": true,
      \\\"start_join\\\": [\\\"\$IP\\\", \$PEERS]
-  }\" > /usr/local/etc/consul.d/agent.json
+}\" > /usr/local/etc/consul.d/agent.json
 
      echo \"consul_args=\\\"-advertise \$IP\\\"\" >> /etc/rc.conf
 


### PR DESCRIPTION
Enabling gossip encryption with a pre-generated key. THIS MUST NOT BE USED IN PRODUCTION!

In production use, first generate a new key with ```consul keygen``` on an existing consul host, even if temporary for this purpose.

Then pass in the key with the parameter ```-E GOSSIPKEY=<new key>```