### PR TITLE
enabling gossip encryption for consul agent and nomad-server

### DIFF
--- a/nomad-server/CHANGELOG.md
+++ b/nomad-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.0.3
+
+* Updated to use gossip encryption for consul and nomad (re-using key)
+
+---
+
 2.0.2
 
 * Updated to use local consul agent

--- a/nomad-server/README.md
+++ b/nomad-server/README.md
@@ -25,11 +25,15 @@ Please note that a specific network configuration is suggested (see Installation
   e.g.
   ```sudo pot clone -P nomad-server-amd64-13_2_0_2 -p my-nomad-server -N alias -i "em0|10.10.10.11"```   
 * Adjust to your environment:    
-  ```sudo pot set-env -p <clonejailname> -E DATACENTER=<datacentername> -E NODENAME=<name of this node> -E IP=<IP address of this nomad instance> -E CONSULSERVERS=<'"list", "of", "consul", "IPs"'> -E BOOTSTRAP=<1|3|5>```
+  ```sudo pot set-env -p <clonejailname> -E DATACENTER=<datacentername> -E NODENAME=<name of this node> -E IP=<IP address of this nomad instance> -E CONSULSERVERS=<'"list", "of", "consul", "IPs"'> -E BOOTSTRAP=<1|3|5> -E GOSSIPKEY=<32 byte Base64 key from consul keygen> -E NOMADKEY=<16 byte or 32 byte key from nomad operator keygen>```
 
 The CONSULSERVERS parameter defines the consul server instances, and must be set as ```CONSULSERVERS='"10.0.0.2"'```` or ```CONSULSERVERS='"10.0.0.2", "10.0.0.3", "10.0.0.4"'``` or ```CONSULSERVERS='"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5", "10.0.0.6"'```
 
 The BOOTSTRAP parameter defines the expected number of cluster nodes, it defaults to 1 (no cluster) if it is not set. You MUST still pass in a consul IP under CONSULSERVERS.
+
+The GOSSIPKEY parameter is the gossip encryption key for consul agent. We're using a default key. Do not use in production.
+
+The NOMADKEY parameter is the gossip encryption key for nomad. We're re-using the default key from consul as nomad supports 32 byte Base64 keys, but the common one is a 16 byte Bas64 key from ```nomad operator keygen```
 
 # Usage
 


### PR DESCRIPTION
Updated to include pre-generated encryption key from [consul image](https://github.com/hny-gd/potluck/tree/master/consul), which is used for consul gossip encryption and re-used for nomad gossip encryption.

For production use please configure:
* your own keys on a single-use ```consul``` server with ```consul keygen``` for a 32 byte base64 key.
* your own keys on a single-use ```nomad``` server with ```nomad operator keygen``` for 16 byte base64 key, or generate your own 32 byte base64 string with ```openssl rand -base64 32``` 