### PR TITLE
updating for consul gossip encryption pre-generated key

### DIFF
--- a/vault/CHANGELOG.md
+++ b/vault/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.0.1
+
+* Updated to use pre-generated consol encryption key for gossip, planning for TLS
+
+---
 2.0
 
 * Updated to use local consol agent and a consul cluster for data store

--- a/vault/README.md
+++ b/vault/README.md
@@ -19,9 +19,11 @@ The flavour expects a local ```consul``` agent instance to be available that it 
 * Export the ports after creating the jail:     
   ```pot export-ports -p <jailname> -e 8200:8200```   
 * Adjust to your environment:    
-  ```sudo pot set-env -p <jailname> -E DATACENTER=<datacentername> -E NODENAME=<nodename> -E CONSULSERVERS=<correctly-quoted-array-consul-IPs> -E IP=<IP address of this vault node>```
+  ```sudo pot set-env -p <jailname> -E DATACENTER=<datacentername> -E NODENAME=<nodename> -E CONSULSERVERS=<correctly-quoted-array-consul-IPs> -E IP=<IP address of this vault node> [-E GOSSIPKEY=<32 byte Base64 key from consul keygen>]```
 
 The CONSULSERVERS parameter defines the consul server instances, and must be set as ```CONSULSERVERS='"10.0.0.2"'``` or ```CONSULSERVERS='"10.0.0.2", "10.0.0.3", "10.0.0.4"'``` or ```CONSULSERVERS='"10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5", "10.0.0.6"'```
+
+The GOSSIPKEY parameter is the gossip encryption key for consul agent. We're using a default key. Do not use in production.
 
 # Usage
 

--- a/vault/vault.sh
+++ b/vault/vault.sh
@@ -168,6 +168,14 @@ if [ -z \${IP+x} ]; then
     echo 'IP is unset - see documentation how to configure this flavour'
     exit 1
 fi
+# GOSSIPKEY is a 32 byte, Base64 encoded key generated with consul keygen for the consul flavour.
+# Re-used for nomad, which is usually 16 byte key but supports 32 byte, Base64 encoded keys
+# We'll re-use the one from the consul flavour
+if [ -z \${GOSSIPKEY+x} ];
+then
+    echo 'GOSSIPKEY is unset - see documentation how to configure this flavour, defaulting to preset encrypt key. Do not use this in production!'
+    GOSSIPKEY='\"BY+vavBUSEmNzmxxS3k3bmVFn1giS4uEudc774nBhIw=\"'
+fi
 
 # ADJUST THIS BELOW: NOW ALL THE CONFIGURATION FILES NEED TO BE CREATED:
 # Don't forget to double(!)-escape quotes and dollar signs in the config files
@@ -190,6 +198,7 @@ echo \"{
  },
  \\\"log_file\\\": \\\"/var/log/consul/\\\",
  \\\"log_level\\\": \\\"WARN\\\",
+ \\\"encrypt\\\": \$GOSSIPKEY,
  \\\"start_join\\\": [ \$CONSULSERVERS ]
 }\" > /usr/local/etc/consul.d/agent.json
 
@@ -241,6 +250,14 @@ storage \\\"consul\\\" {
   address = \\\"\$IP:8500\\\"
   server_service_name = \\\"\$DATACENTER-server\\\"
   path = \\\"vault/\\\"
+  scheme = \\\"http\\\"
+  # for future usage with https and keys
+  # set tls_disable to 0 above when enabling
+  #token = \\\"abcd1234\\\"
+  #scheme = \\\"https\\\"
+  #tls_ca_file   = \\\"/etc/pem/vault.ca\\\"
+  #tls_cert_file = \\\"/etc/pem/vault.cert\\\"
+  #tls_key_file  = \\\"/etc/pem/vault.key\\\"
 }
 telemetry {
   statsite_address = \\\"\$IP:8125\\\"


### PR DESCRIPTION
updating the local consul agent config to use pre-generated key. Do not use in production, pass in a new key with the ```-E GOSSIPKEY=<key>``` parameter.

preparation for TLS added to vault config.