### PR TITLE
updating for consul gossip encryption key

### DIFF
--- a/postgresql-patroni/CHANGELOG.md
+++ b/postgresql-patroni/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.0.2
+
+* Consul pre-generated gossip encryption key added
+
+---
+
 2.0.1
 
 * Fixing up minor type with trailing comma in consul agent.json setup

--- a/postgresql-patroni/README.md
+++ b/postgresql-patroni/README.md
@@ -15,12 +15,13 @@ For more details about ```nomad``` images, see [about potluck](https://potluck.h
 
 The jail exposes these parameters that can either be set via the environment or by setting the ```cook```parameters (the latter either via ```nomad```, see example below, or by editing the downloaded jails ```pot.conf``` file):
 
-| Environment | Content    | Unfilled column    |
-| :---------- | :----------------: | :-----------|
-| DATACENTER  | - datacentre name                 | ...  |
-| NODENAME    | - unique name for node, each patroni-postgresql instance must have unique name                 | ...       |
-| MYIP        | - IP address of this node                 | ...                  |
-| SERVICETAG  | - service tag for node (master/replica/standby-leader)     | ...                  |
-| CONSULSERVERS | - IPs of consul cluster in format ```'"x.x.x.x", "y.y.y.y", "z.z.z.z"'```                 | ...             |
-| ADMPASS     | - admin password                 | ...                  |
-| KEKPASS     | - postgresql super user password                 | ...                  |
+| Environment   | Content    | Unfilled column    |
+| :----------   | :----------------: | :-----------|
+| DATACENTER    | - datacentre name                                                               | ...    |
+| NODENAME      | - unique name for node, each patroni-postgresql instance must have unique name  | ...    |
+| MYIP          | - IP address of this node                                                       | ...    |
+| SERVICETAG    | - service tag for node (master/replica/standby-leader)                          | ...    |
+| CONSULSERVERS | - IPs of consul cluster in format ```'"x.x.x.x", "y.y.y.y", "z.z.z.z"'```       | ...    |
+| ADMPASS       | - admin password                                                                | ...    |
+| KEKPASS       | - postgresql super user password                                                | ...    |
+| GOSSIPKEY     | - consul gossip encryption key in 32 byte base64 format                         | ...    |

--- a/postgresql-patroni/postgresql-patroni.sh
+++ b/postgresql-patroni/postgresql-patroni.sh
@@ -218,6 +218,14 @@ then
     echo 'KEKPASS is unset - see documentation how to configure this flavour'
     KEKPASS=kekpass
 fi
+# GOSSIPKEY is a 32 byte, Base64 encoded key generated with consul keygen for the consul flavour.
+# Re-used for nomad, which is usually 16 byte key but supports 32 byte, Base64 encoded keys
+# We'll re-use the one from the consul flavour
+if [ -z \${GOSSIPKEY+x} ];
+then
+    echo 'GOSSIPKEY is unset - see documentation how to configure this flavour, defaulting to preset encrypt key. Do not use this in production!'
+    GOSSIPKEY='\"BY+vavBUSEmNzmxxS3k3bmVFn1giS4uEudc774nBhIw=\"'
+fi
 
 # make consul configuration directory and set permissions
 mkdir -p /usr/local/etc/consul.d
@@ -235,6 +243,7 @@ echo \"{
  },
  \\\"log_file\\\": \\\"/var/log/consul/\\\",
  \\\"log_level\\\": \\\"WARN\\\",
+ \\\"encrypt\\\": \$GOSSIPKEY,
  \\\"start_join\\\": [ \$CONSULSERVERS ]
 }\" > /usr/local/etc/consul.d/agent.json
 
@@ -258,7 +267,7 @@ touch /var/log/consul/consul.log
 chown -R consul:wheel /var/log/consul
 
 # add the consul user to the wheel group, this seems to be required for
-# consul to start on this instance. May need to figure out why. 
+# consul to start on this instance. May need to figure out why.
 # I'm not entirely sure this is the correct way to do it
 /usr/sbin/pw usermod consul -G wheel
 


### PR DESCRIPTION
Updating to use the pre-generated consul gossip encryption key. DO NOT USE IN PRODUCTION, instead supply a new key with the ```-E GOSSIPKEY=<32 byte base64 key>``` parameter.