### PR TITLE
updating to use consul agent to publish node_exporter service

### DIFF
--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.9.1
+
+* Updating to use consul for announcing node_exporter as a service
+
+---
+
 0.9
 
 * First test build of Prometheus with node_exporter and Grafana7

--- a/prometheus/prometheus.d/prometheus.yml
+++ b/prometheus/prometheus.d/prometheus.yml
@@ -20,3 +20,12 @@ scrape_configs:
   - job_name: 'node'
     static_configs:
     - targets: [ MYTARGETS ]
+  - job_name: 'consul'
+    consul_sd_configs:
+    - server: 'localhost:8500'
+    relabel_configs:
+      - source_labels: [__meta_consul_tags]
+        regex: .*,prometheus,.*
+        action: keep
+      - source_labels: [__meta_consul_service]
+        target_label: job

--- a/prometheus/prometheus.sh
+++ b/prometheus/prometheus.sh
@@ -206,7 +206,12 @@ echo \"{
  \\\"log_file\\\": \\\"/var/log/consul/\\\",
  \\\"log_level\\\": \\\"WARN\\\",
  \\\"encrypt\\\": \$GOSSIPKEY,
- \\\"start_join\\\": [ \$CONSULSERVERS ]
+ \\\"start_join\\\": [ \$CONSULSERVERS ],
+ \\\"service\\\": {
+  \\\"name\\\": \\\"node_exporter\\\",
+  \\\"tags\\\": [\\\"_app=prometheus\\\", \\\"_service=node_exporter\\\", \\\"_hostname=\$NODENAME\\\"],
+  \\\"port\\\": 9100
+ }
 }\" > /usr/local/etc/consul.d/agent.json
 
 # set owner and perms on agent.json


### PR DESCRIPTION
This might be able to replace manual config of scrape targets for prometheus, by publishing the details in consul as a service. Updating image to enable this automatically.

All images using consul can publish their node_exporter service this way.