### PR TITLE
Don't make vault start on boot by default

### DIFF
--- a/vault/vault
+++ b/vault/vault
@@ -1,1 +1,1 @@
-set-attribute -A start-at-boot -V YES
+


### PR DESCRIPTION
We really only want to set this manually after cloning the pot.