### PR TITLE
prometheus: Block web admin api endpoint in proxy

### DIFF
--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.12.7
+
+* Protect admin web api endpoint in nginx proxy
+* Web admin api endpoint is still disabled by default, but can be enabled temporarily for maintenance tasks
+
+---
+
 0.12.6
 
 * Make consul-template retry more often

--- a/prometheus/prometheus.d/local/share/cook/templates/prometheusproxy.conf.in
+++ b/prometheus/prometheus.d/local/share/cook/templates/prometheusproxy.conf.in
@@ -40,6 +40,10 @@ http {
           proxy_pass http://127.0.0.1:9090;
         }
 
+        location /api/v1/admin {
+          return 403;
+        }
+
         # redirect server error pages to the static page /50x.html
         #
         error_page   500 502 503 504  /50x.html;

--- a/prometheus/prometheus.ini
+++ b/prometheus/prometheus.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="prometheus"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.12.6"
+version="0.12.7"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
This allows admins to temporarily enable the web admin api endpoint without exposing it to the outside world.