### PR TITLE
Unset timezone in grafana dashboards to use the default

### DIFF
--- a/beast-of-argh/beast-of-argh.d/local/share/cook/templates/home.json.in
+++ b/beast-of-argh/beast-of-argh.d/local/share/cook/templates/home.json.in
@@ -3673,7 +3673,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Node Exporter for FreeBSD",
   "uid": "abcDef",
   "variables": {

--- a/beast-of-argh/beast-of-argh.d/local/share/cook/templates/postgres.json.in
+++ b/beast-of-argh/beast-of-argh.d/local/share/cook/templates/postgres.json.in
@@ -1431,7 +1431,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Postgres Overview",
   "uid": "wGgaPlciz",
   "version": 1

--- a/beast-of-argh/beast-of-argh.d/local/share/cook/templates/redis.json.in
+++ b/beast-of-argh/beast-of-argh.d/local/share/cook/templates/redis.json.in
@@ -2824,7 +2824,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Redis Golden Signals",
   "uid": "828nin20oinani2",
   "version": 1

--- a/grafana/grafana.d/local/share/cook/templates/home.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/home.json.in
@@ -3673,7 +3673,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Node Exporter for FreeBSD",
   "uid": "abcDef",
   "variables": {

--- a/grafana/grafana.d/local/share/cook/templates/home.json.old
+++ b/grafana/grafana.d/local/share/cook/templates/home.json.old
@@ -13976,7 +13976,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Node Exporter Full",
   "uid": "rYdddlPWk",
   "version": 56

--- a/grafana/grafana.d/local/share/cook/templates/postgres.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/postgres.json.in
@@ -1431,7 +1431,7 @@
       "30d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "",
   "title": "Postgres Overview",
   "uid": "wGgaPlciz",
   "version": 5


### PR DESCRIPTION
Hello. I have a suggestion to remove `timezone: "browser"` from `home`, `redis` and `prometheus` grafana dashboards so that it would match all the other dashboards (uses the default Server or Organization timezone).

With this change - changing the timezone in `grafana.conf.in`
```diff
--default_timezone = browser
++default_timezone = UTC
```
will change the timezone through the whole Grafana and will be single source of truth.