### PR TITLE
prometheus: Optimize certificate rotation

### DIFF
--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.16.0
+
+* Optimize reloading of services on cert rotation
+
+---
+
 0.15.1
 
 * Version bump for new base image

--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.16.1
+
+* Make sure prometheus and alertmanager are started when an already provisioned image boots a second time
+
+---
+
 0.16.0
 
 * Optimize reloading of services on cert rotation

--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -1,10 +1,10 @@
-0.16.1
+0.15.3
 
 * Make sure prometheus and alertmanager are started when an already provisioned image boots a second time
 
 ---
 
-0.16.0
+0.15.2
 
 * Optimize reloading of services on cert rotation
 

--- a/prometheus/prometheus.d/local/bin/cook
+++ b/prometheus/prometheus.d/local/bin/cook
@@ -101,6 +101,12 @@ if [ -e /usr/local/etc/pot-is-seasoned ]; then
         log "Seasoned: Wait until we are able to resolve vault leader"
         timeout --foreground 120 \
           sh -c 'while ! host -ta active.vault.service.consul; do sleep 1; done'
+
+        log "Start prometheus"
+        service prometheus start
+
+        log "Start alertmanager"
+        service alertmanager start >/dev/null 2>&1
     fi
 
     pot_seasoned_exit

--- a/prometheus/prometheus.d/local/bin/cook
+++ b/prometheus/prometheus.d/local/bin/cook
@@ -248,7 +248,7 @@ log "Start prometheus"
 service prometheus start
 
 log "Start alertmanager"
-service alertmanager start
+service alertmanager start >/dev/null 2>&1
 
 # syslog-ng start is set in the script because it won't run if REMOTELOG
 # is empty or null

--- a/prometheus/prometheus.d/local/share/cook/bin/reload-metrics.sh
+++ b/prometheus/prometheus.d/local/share/cook/bin/reload-metrics.sh
@@ -11,8 +11,7 @@ if service syslog-ng enabled; then
 fi
 
 service nginx reload nodemetricsproxy
-service prometheus restart
-service alertmanager restart >/dev/null 2>&1
+service prometheus reload
 service nginx reload prometheusproxy
 
 exit 0

--- a/prometheus/prometheus.ini
+++ b/prometheus/prometheus.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="prometheus"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.15.1"
+version="0.16.0"
 origin="freebsd"
 runs_in_nomad="false"

--- a/prometheus/prometheus.ini
+++ b/prometheus/prometheus.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="prometheus"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.16.0"
+version="0.16.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/prometheus/prometheus.ini
+++ b/prometheus/prometheus.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="prometheus"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.16.1"
+version="0.15.3"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
Alertmanager does not need to get restarted anymore and for prometheus,
reload is enough these days.