### PR TITLE
loki, prometheus: Add Loki metrics to Consul and scrape it with Prometheus

### DIFF
--- a/loki/CHANGELOG.md
+++ b/loki/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.2.26
+
+* Add Loki metrics endpoint as a service in Consul
+
+---
+
 0.2.25
 
 * More fixes to loki and promtail

--- a/loki/loki.d/local/share/cook/templates/consul-agent.hcl.in
+++ b/loki/loki.d/local/share/cook/templates/consul-agent.hcl.in
@@ -41,6 +41,12 @@ services = {
           "_hostname=%%nodename%%.%%datacenter%%.consul"]
   port = 9103
 }
+services = {
+  name = "loki-metrics"
+  tags = ["_app=loki", "_service=loki-metrics",
+          "_hostname=%%nodename%%.%%datacenter%%.consul"]
+  port = 3100
+}
 telemetry = {
   prometheus_retention_time = "24h"
 }

--- a/loki/loki.ini
+++ b/loki/loki.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="loki"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.2.25"
+version="0.2.26"
 origin="freebsd"
 runs_in_nomad="false"

--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.15.4
+
+* Add Loki metrics Consul service as a scrape target
+
+---
+
 0.15.3
 
 * Make sure prometheus and alertmanager are started when an already provisioned image boots a second time

--- a/prometheus/prometheus.d/local/share/cook/templates/prometheus.yml.in
+++ b/prometheus/prometheus.d/local/share/cook/templates/prometheus.yml.in
@@ -31,6 +31,7 @@ scrape_configs:
         - postgres-exporter
         - prometheus-json-metrics-exporter
         - prometheus-log-exporter
+        - loki-metrics
       datacenter: '%%datacenter%%'
     relabel_configs:
     - source_labels: ['__meta_consul_service']

--- a/prometheus/prometheus.ini
+++ b/prometheus/prometheus.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="prometheus"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.15.3"
+version="0.15.4"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
Adds Loki metrics endpoint as a service in Consul and configures Prometheus to scrape it.

Nginx configs already have a proxy set up for port 3100.