### PR TITLE
loki: Switch loki and promtail back to upstream versions

### DIFF
--- a/loki/CHANGELOG.md
+++ b/loki/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.3.2
+
+* Return to upstream versions of loki and promtail
+* This uses rc scripts taken from the port (including some strangeness), so we can switch back in the future and stay compatible
+
+---
+
 0.3.1
 
 * Version bump for new base image 14.1

--- a/loki/loki.d/local/share/cook/bin/configure-loki.sh
+++ b/loki/loki.d/local/share/cook/bin/configure-loki.sh
@@ -20,6 +20,10 @@ mkdir -p /mnt/loki/rules-temp
 #sep=$'\001'
 
 # loki setup
+
+# copy in loki rc
+cp "$TEMPLATEPATH/loki.rc.in" /usr/local/etc/rc.d/loki
+chmod +x /usr/local/etc/rc.d/loki
 service loki enable
 sysrc loki_args="-frontend.instance-addr=127.0.0.1"
 sysrc loki_config=/usr/local/etc/loki-local-config.yaml
@@ -28,10 +32,6 @@ sysrc loki_logfile="/mnt/log/loki/loki.log"
 # patch startup script
 sed -i '' 's/command_args="-p/command_args="-f -p/' \
   /usr/local/etc/rc.d/loki
-
-# prepare logdir
-mkdir -p /mnt/log/loki
-chown loki:loki /mnt/log/loki
 
 # copy in loki config file
 if [ -f /mnt/loki/loki-local-config.yaml.in ]; then
@@ -42,10 +42,25 @@ else
 	  /usr/local/etc/loki-local-config.yaml
 fi
 
+# create loki group
+/usr/sbin/pw groupadd -n loki -g 967
+
+# create loki user
+/usr/sbin/pw useradd -n loki -c 'Loki' -m -k /var/empty \
+  -d /var/db/loki -u 916 -s /usr/bin/nologin -h -
+
+# prepare logdir
+mkdir -p /mnt/log/loki
+chown loki:loki /mnt/log/loki
+
 # chown to loki user
 chown -R loki:loki /mnt/loki
 
 # promtail setup
+
+# copy in the promtail rc file
+cp "$TEMPLATEPATH/promtail.rc.in" /usr/local/etc/rc.d/promtail
+chmod +x /usr/local/etc/rc.d/promtail
 service promtail enable
 sysrc promtail_config="/usr/local/etc/promtail-local-config.yaml"
 sysrc promtail_logfile="/mnt/log/promtail/promtail.log"
@@ -53,6 +68,13 @@ sysrc promtail_logfile="/mnt/log/promtail/promtail.log"
 # patch startup script
 sed -i '' 's/command_args="-p/command_args="-f -p/' \
   /usr/local/etc/rc.d/promtail
+
+# create promtail group
+/usr/sbin/pw groupadd -n promtail -g 968
+
+# create promtail user
+/usr/sbin/pw useradd -n promtail -c 'Promtail' -m -k /var/empty \
+  -d /var/db/promtail -u 816 -s /usr/bin/nologin -h -
 
 # prepare logdir
 mkdir -p /mnt/log/promtail

--- a/loki/loki.d/local/share/cook/templates/loki.rc.in
+++ b/loki/loki.d/local/share/cook/templates/loki.rc.in
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+# PROVIDE: loki
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+
+# Add the following lines to /etc/rc.conf to enable loki
+# loki_enable="YES"
+#
+# loki_enable (bool):
+#     Set it to YES to enable grafana
+#     Set to NO by default
+# loki_user (string):
+#     Set user that grafana will run under
+#     Default is "loki"
+# loki_group (string):
+#     Set group that own grafana files
+#     Default is "loki"
+# loki_config (string)
+#     Set full path to config file
+#     Default is "/usr/local/etc/loki.yaml"
+# loki_logfile (string)
+#     Set full path to log file
+#     Default is "/var/log/loki/loki.log"
+# loki_loglevel (string)
+#     Set log level. Only log messages with the given severity or above.
+#     Valid levels: [debug, info, warn, error]
+#     Default is "warn"
+# loki_args (string)
+#     Set additional command line arguments
+#     Default is ""
+
+. /etc/rc.subr
+
+name=loki
+rcvar=loki_enable
+
+load_rc_config $name
+
+: ${loki_enable:="NO"}
+: ${loki_user:="loki"}
+: ${loki_group:="loki"}
+: ${loki_config:="/usr/local/etc/loki.yaml"}
+: ${loki_logfile:="/var/log/loki/loki.log"}
+: ${loki_loglevel:="warn"}
+
+pidfile="/var/run/${name}/${name}.pid"
+required_files="${loki_config}"
+
+procname="/usr/local/bin/loki"
+command="/usr/sbin/daemon"
+command_args="-p ${pidfile} -t ${name} -o ${loki_logfile} \
+	${procname} \
+	--config.file=${loki_config} \
+	--log.level=${loki_loglevel} \
+	${loki_args}"
+
+start_precmd="loki_start_precmd"
+
+loki_start_precmd()
+{
+	if [ ! -d "/var/run/${name}" ]; then
+		install -d -m 0750 -o ${loki_user} -g ${loki_group} "/var/run/${name}"
+	fi
+
+	if [ ! -d "/var/log/loki" ]; then
+		install -d -m 0750 -o ${loki_user} -g ${loki_group} "/var/log/loki"
+	fi
+}
+
+run_rc_command "$1"

--- a/loki/loki.d/local/share/cook/templates/promtail.rc.in
+++ b/loki/loki.d/local/share/cook/templates/promtail.rc.in
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+# PROVIDE: promtail
+# REQUIRE: LOGIN
+# KEYWORD: shutdown
+
+# Add the following lines to /etc/rc.conf to enable promtail
+# promtail_enable="YES"
+#
+# promtail_enable (bool):
+#     Set it to YES to enable promtail
+#     Set to NO by default
+# promtail_user (string):
+#     Set user that promtail will run under
+#     Default is "promtail"
+# promtail_group (string):
+#     Set group that own promtail files
+#     Default is "loki"
+# promtail_config (string)
+#     Set full path to config file
+#     Default is "/usr/local/etc/promtail.yaml"
+# promtail_logfile (string)
+#     Set full path to log file
+#     Default is "/var/log/promtail/promtail.log"
+# promtail_loglevel (string)
+#     Set log level. Only log messages with the given severity or above.
+#     Valid levels: [debug, info, warn, error]
+#     Default is "warn"
+# promtail_args (string)
+#     Set additional command line arguments
+#     Default is ""
+
+. /etc/rc.subr
+
+name=promtail
+rcvar=promtail_enable
+
+load_rc_config $name
+
+: ${promtail_enable:="NO"}
+: ${promtail_user:="promtail"}
+: ${promtail_group:="loki"}
+: ${promtail_config:="/usr/local/etc/promtail.yaml"}
+: ${promtail_logfile:="/var/log/promtail/promtail.log"}
+: ${promtail_loglevel:="warn"}
+
+pidfile="/var/run/${name}/${name}.pid"
+required_files="${promtail_config}"
+
+procname="/usr/local/bin/promtail"
+command="/usr/sbin/daemon"
+command_args="-p ${pidfile} -t ${name} -o ${promtail_logfile} \
+	${procname} \
+	--config.file=${promtail_config} \
+	--log.level=${promtail_loglevel} \
+	${promtail_args}"
+
+start_precmd="promtail_start_precmd"
+
+promtail_start_precmd() {
+	if [ ! -d "/var/run/${name}" ]; then
+		install -d -m 0750 -o ${promtail_user} -g ${promtail_group} "/var/run/${name}"
+	fi
+
+	if [ ! -d "/var/log/promtail" ]; then
+		install -d -m 0750 -o ${promtail_user} -g ${promtail_group} "/var/log/promtail"
+	fi
+}
+
+run_rc_command "$1"

--- a/loki/loki.ini
+++ b/loki/loki.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="loki"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.3.1"
+version="0.3.2"
 origin="freebsd"
 runs_in_nomad="false"

--- a/loki/loki.sh
+++ b/loki/loki.sh
@@ -128,11 +128,32 @@ pkg install -y vault
 step "Install package syslog-ng"
 pkg install -y syslog-ng
 
-step "Install package grafana-loki"
-pkg install -y grafana-loki
-
 step "Clean package installation"
 pkg clean -ay
+
+# last updated 2024-10-11
+step "Download loki release from github"
+fetch -qo - https://github.com/grafana/loki/releases/download/\
+v3.2.0/loki-freebsd-amd64.zip | unzip -p - loki-freebsd-amd64 \
+  >/usr/local/bin/loki
+chmod 755 /usr/local/bin/loki
+
+if [ "$(sha256 -q /usr/local/bin/loki)" != \
+  "e104034dec55f2ce55492d102f45ac1729567a88d41357ea10d0f61bf58e446c" ]; then
+  exit_error "/usr/local/bin/loki checksum mismatch!"
+fi
+
+# last updated 2024-10-11
+step "Download promtail release from github"
+fetch -qo - https://github.com/grafana/loki/releases/download/\
+v3.2.0/promtail-freebsd-amd64.zip | unzip -p - promtail-freebsd-amd64 \
+  >/usr/local/bin/promtail
+chmod 755 /usr/local/bin/promtail
+
+if [ "$(sha256 -q /usr/local/bin/promtail)" != \
+  "38e730412eee148c0d5d178bdd49b802974492b74fd32d192bcd1ca81a66b4bb" ]; then
+  exit_error "/usr/local/bin/promtail checksum mismatch!"
+fi
 
 # -------------- END PACKAGE SETUP -------------
 


### PR DESCRIPTION
RC scripts are taken from the FreeBSD port as is, so we can switch back to the package at some point (right now it's not moving fast enough and not at predictable times).

UIDs and GIDs are the same as the package would use.