### PR TITLE
loki: Improve varlogs parsing, remove syslog scrape_config

### DIFF
--- a/loki/CHANGELOG.md
+++ b/loki/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3.5
+
+* Remove syslog log target from promtail and syslog-ng.conf and improve parsing of the varlogs target. This allows reingesting logs after disaster. Also parse severity.
+
+---
+
 0.3.4
 
 * Add Loki metrics endpoint as a service in Consul (restores the "lost" version 0.2.26)

--- a/loki/loki.d/local/share/cook/templates/promtail-local-config.yaml.in
+++ b/loki/loki.d/local/share/cook/templates/promtail-local-config.yaml.in
@@ -11,60 +11,23 @@ clients:
   - url: http://127.0.0.1:3100/loki/api/v1/push
 
 scrape_configs:
-  - job_name: system
+  - job_name: varlogs
     static_configs:
       - targets:
           - localhost
         labels:
           job: varlogs
           __path__: /mnt/log/remote/*.log
-
-  - job_name: syslog
-    syslog:
-      listen_address: 127.0.0.1:1514
-      idle_timeout: 60s
-      label_structured_data: yes
-      labels:
-        job: "syslog"
     pipeline_stages:
-      - match:
-          selector: '{job = "syslog"} |= "query_range?"'
-          action: drop
-          drop_counter_reason: loki_dashboard_query_logs
-      - match:
-          selector: '{job = "syslog"} |= "domainevent -"'
-          stages:
-            - regex:
-                expression: 'domainevent - (?P<event_name>.*)/(?P<event_id>.*)/(?P<event_kind>.*) (?P<json_str>{.*})'
-            - labels:
-                event_name:
-                event_id:
-                event_kind:
-            - static_labels:
-                log_source: "DomainEvent"
-            - output:
-                source: json_str
-            - timestamp:
-                source: timestamp
-                format: RFC3339Nano
-      # whatever tags you can extract from your json logs
-      - match:
-          selector: '{job = "syslog"} |= "json -"'
-          stages:
-            - regex:
-                expression: "json - '(?P<json_str>.*)'"
-            - output:
-                source: json_str
-            - json:
-                expressions:
-                  message: '"@message"'
-                  level: '"@level"'
-            - static_labels:
-                log_source: "Product"
-            - timestamp:
-                source: timestamp
-                format: RFC3339Nano
-    relabel_configs:
-      - source_labels: ['__syslog_message_hostname']
-        target_label: 'host'
-
+      - regex:
+          # ts, host & msg data mandatory; lvl extracted only if exists
+          # log levels https://docs.freebsd.org/en/books/handbook/config/#logging-levels
+          expression: '^(?P<ts>2\S+) (?P<host>(?:\d{1,3}\.){3}\d{1,3}) (?:(?P<lvl>emerg|alert|crit|err|warning|notice|info|debug|none) )?(?P<msg>.*)'
+      - labels:
+          host: host
+          severity: lvl
+      - timestamp:
+          source: ts
+          format: RFC3339
+      - output:
+          source: msg

--- a/loki/loki.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/loki/loki.d/local/share/cook/templates/syslog-ng.conf.in
@@ -16,6 +16,11 @@ options {
  ts_format(iso);
 };
 
+# template to include severity
+template t_withseverity {
+ template("${ISODATE} ${HOST} ${SEVERITY} ${MSGHDR}${MSG}\n");
+};
+
 # local sources
 source src {
  system();
@@ -68,6 +73,7 @@ destination lokilogs {
     owner(root)
     group(promtail)
     perm(0640)
+    template(t_withseverity)
   );
 };
 destination jsonmetricslog {
@@ -86,17 +92,6 @@ destination loghost {
    peer-verify(required-trusted)
   )
  );
-};
-
-destination lokisyslog {
-  syslog("127.0.0.1" transport("tcp") port(1514)
-    disk-buffer(
-      mem-buf-size(536870912)    # 512MiB
-      disk-buf-size(10737418240) # 10GiB
-      reliable(yes)
-      dir("/mnt/log/syslog-ng-disk-buffer")
-    )
-);
 };
 
 # log facility filters
@@ -212,6 +207,5 @@ log {
     destination(jsonmetricslog);
   } else {
     destination(lokilogs);
-    destination(lokisyslog);
   };
 };

--- a/loki/loki.ini
+++ b/loki/loki.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="loki"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.3.4"
+version="0.3.5"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
The improved varlogs gives proper log input (can be enhanced of needed to ingest more) and is suitable for re-import of logs after a downtime or upgrading the loki backend db (bolt to tsdb).