### PR TITLE
update syslog-ng configs with modern options

### DIFF
--- a/adminer/CHANGELOG.md
+++ b/adminer/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
-* 
+* Update syslog-ng config to use modern config options
+
 ---
 
 0.8

--- a/adminer/adminer.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/adminer/adminer.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -46,12 +46,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/adminer/adminer.ini
+++ b/adminer/adminer.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="adminer"
 author="Deividas Gedgaudas"
-version="0.9.2"
+version="0.9.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/beast-of-argh/CHANGELOG.md
+++ b/beast-of-argh/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
  
 ---
 

--- a/beast-of-argh/beast-of-argh.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/beast-of-argh/beast-of-argh.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(40000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -37,12 +37,13 @@ source s_promtail {
 # https://www.syslog-ng.com/technical-documents/doc/\
 # syslog-ng-open-source-edition/3.19/administration-guide/53
 source mynetwork {
- tcp(
+ network(
   ip(0.0.0.0)
   port(514)
+  transport(tcp)
   max-connections(300)
   log-iw-size(30000)
-  so_keepalive(yes)
+  so-keepalive(yes)
  );
 };
 
@@ -79,15 +80,22 @@ destination jsonmetricslog {
   );
 };
 destination loghost {
-  tcp("%%myip%%" port(514)
- );
+  network(
+    "%%myip%%"
+    port(514)
+    transport(tcp)
+  );
 };
 
 destination lokisyslog {
-  syslog("127.0.0.1" transport("tcp") port(1514)
+  syslog(
+    "127.0.0.1"
+    port(1514)
+    transport("tcp")
     disk-buffer(
-      mem-buf-size(536870912)    # 512MiB
-      disk-buf-size(10737418240) # 10GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(536870912) # 512MiB
+      capacity-bytes(10737418240) # 10GiB
       reliable(yes)
       dir("/mnt/logs/syslog-ng-disk-buffer")
     )

--- a/beast-of-argh/beast-of-argh.ini
+++ b/beast-of-argh/beast-of-argh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="beast-of-argh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.22.2"
+version="0.22.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/beast-of-argh/client-syslog-ng.conf.sample
+++ b/beast-of-argh/client-syslog-ng.conf.sample
@@ -8,16 +8,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -52,12 +52,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/consul-tls/CHANGELOG.md
+++ b/consul-tls/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Version bump for new base image 14.1
 * Extra steps to trim image size
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/consul-tls/consul-tls.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/consul-tls/consul-tls.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,9 +43,10 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(6514)
+    transport(tls)
     tls(
       key-file("/mnt/metricscerts/metrics.key")
       cert-file("/mnt/metricscerts/metrics.crt")
@@ -53,8 +54,9 @@ destination loghost {
       peer-verify(required-trusted)
     )
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/mnt/log/syslog-ng-disk-buffer")
     )

--- a/consul-tls/consul-tls.ini
+++ b/consul-tls/consul-tls.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="consul-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.5.2"
+version="0.5.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
  
 ---
 

--- a/consul/consul.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/consul/consul.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/consul/consul.ini
+++ b/consul/consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.21.2"
+version="2.21.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/dmarc-report/CHANGELOG.md
+++ b/dmarc-report/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
  
 ---
 

--- a/dmarc-report/dmarc-report.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/dmarc-report/dmarc-report.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -46,12 +46,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/dmarc-report/dmarc-report.ini
+++ b/dmarc-report/dmarc-report.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="dmarc-report"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.17.2"
+version="0.17.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/grafana/CHANGELOG.md
+++ b/grafana/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.7.3
+
+* Update syslog-ng config to use modern config options
+
+---
+
 0.7.2
 
 * Enable milliseconds in syslog-ng for all log timestamps

--- a/grafana/grafana.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/grafana/grafana.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,9 +43,10 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(6514)
+    transport(tls)
     tls(
       key-file("/mnt/metricscerts/metrics.key")
       cert-file("/mnt/metricscerts/metrics.crt")
@@ -53,8 +54,9 @@ destination loghost {
       peer-verify(required-trusted)
     )
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/mnt/log/syslog-ng-disk-buffer")
     )

--- a/grafana/grafana.ini
+++ b/grafana/grafana.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="grafana"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.2"
+version="0.7.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy-consul/CHANGELOG.md
+++ b/haproxy-consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3.3
+
+* Update syslog-ng config to use modern config options
+
+---
+
 0.3.2
 
 * Enable milliseconds in syslog-ng for all log timestamps

--- a/haproxy-consul/haproxy-consul.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/haproxy-consul/haproxy-consul.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,9 +43,10 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(6514)
+    transport(tls)
     tls(
       key-file("/mnt/metricscerts/metrics.key")
       cert-file("/mnt/metricscerts/metrics.crt")
@@ -53,8 +54,9 @@ destination loghost {
       peer-verify(required-trusted)
     )
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/mnt/log/syslog-ng-disk-buffer")
     )

--- a/haproxy-consul/haproxy-consul.ini
+++ b/haproxy-consul/haproxy-consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-consul"
 author = "Michael Gmelin, Bretton Vine"
-version="0.3.2"
+version="0.3.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy-minio/CHANGELOG.md
+++ b/haproxy-minio/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -46,12 +46,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/haproxy-minio/haproxy-minio.ini
+++ b/haproxy-minio/haproxy-minio.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-minio"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.9.2"
+version="0.9.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy-sql/CHANGELOG.md
+++ b/haproxy-sql/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/haproxy-sql/haproxy-sql.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/haproxy-sql/haproxy-sql.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -46,12 +46,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/haproxy-sql/haproxy-sql.ini
+++ b/haproxy-sql/haproxy-sql.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-sql"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.14.2"
+version="0.14.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy/CHANGELOG.md
+++ b/haproxy/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Version bump for p3 rebuild
 * Add checklist
+* Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/haproxy/haproxy.d/syslog-ng.conf
+++ b/haproxy/haproxy.d/syslog-ng.conf
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(40000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -28,12 +28,13 @@ source src {
 # so 300 max connections is (30000+10000) or log-fifo-size of 40000
 # https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.19/administration-guide/53
 source mynetwork {
- tcp(
+ network(
   ip(0.0.0.0)
   port(6514)
+  transport(tls)
   max-connections(300)
   log-iw-size(30000)
-  so_keepalive(yes)
+  so-keepalive(yes)
   flags(no-multi-line)
   tls(
    key-file("/mnt/certs/key.pem")
@@ -65,15 +66,18 @@ destination allusers { usertty("*"); };
 # pot settings
 destination lokilogs { file("/mnt/logs/$HOST.log"); };
 destination loghost {
-  tcp("MYIP" port(6514)
-  tls(
-   key-file("/mnt/certs/key.pem")
-   cert-file("/mnt/certs/cert.pem")
-   ca_dir("/mnt/certs/hash")
-   ca-file("/mnt/certs/combinedca.pem")
-   peer-verify(required-trusted)
-  )
- );
+  network(
+    "MYIP"
+    port(6514)
+    transport(tls)
+    tls(
+      key-file("/mnt/certs/key.pem")
+      cert-file("/mnt/certs/cert.pem")
+      ca-dir("/mnt/certs/hash")
+      ca-file("/mnt/certs/combinedca.pem")
+      peer-verify(required-trusted)
+    )
+  );
 };
 
 # log facility filters

--- a/hugo-nginx-alt/CHANGELOG.md
+++ b/hugo-nginx-alt/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
  
 ---
 

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -47,12 +47,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/hugo-nginx-alt/hugo-nginx-alt.ini
+++ b/hugo-nginx-alt/hugo-nginx-alt.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx-alt"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.9.2"
+version="0.9.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/hugo-nginx/CHANGELOG.md
+++ b/hugo-nginx/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -47,12 +47,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/hugo-nginx/hugo-nginx.ini
+++ b/hugo-nginx/hugo-nginx.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.2"
+version="0.20.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/influxdb/CHANGELOG.md
+++ b/influxdb/CHANGELOG.md
@@ -3,7 +3,8 @@
 * Fix nologin shell for nodeexport user
 * This image is still old format versioning
 * Enable milliseconds in syslog-ng for all log timestamps
-* 
+* Update syslog-ng config to use modern config options
+
 ---
 
 0.0.16

--- a/influxdb/influxdb.d/syslog-ng.conf
+++ b/influxdb/influxdb.d/syslog-ng.conf
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,15 +43,18 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp("REMOTELOGIP" port(6514)
-  tls(
-   key-file("/mnt/certs/key.pem")
-   cert-file("/mnt/certs/cert.pem")
-   ca_dir("/mnt/certs/hash")
-   ca-file("/mnt/certs/combinedca.pem")
-   peer-verify(required-trusted)
-  )
- );
+  network(
+    "REMOTELOGIP"
+    port(6514)
+    transport(tls)
+    tls(
+      key-file("/mnt/certs/key.pem")
+      cert-file("/mnt/certs/cert.pem")
+      ca-dir("/mnt/certs/hash")
+      ca-file("/mnt/certs/combinedca.pem")
+      peer-verify(required-trusted)
+    )
+  );
 };
 
 # log facility filters

--- a/jenkins/CHANGELOG.md
+++ b/jenkins/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/jenkins/jenkins.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/jenkins/jenkins.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/jenkins/jenkins.ini
+++ b/jenkins/jenkins.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="jenkins"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.2"
+version="0.20.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/jitsi-meet/CHANGELOG.md
+++ b/jitsi-meet/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/jitsi-meet/jitsi-meet.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/jitsi-meet/jitsi-meet.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -49,12 +49,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728)   # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/jitsi-meet/jitsi-meet.ini
+++ b/jitsi-meet/jitsi-meet.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="jitsi-meet"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.2"
+version="0.20.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/loki/CHANGELOG.md
+++ b/loki/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3.7
+
+* Update syslog-ng config to use modern config options
+
+---
+
 0.3.6
 
 * Enable milliseconds in syslog-ng for all log timestamps

--- a/loki/loki.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/loki/loki.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(40000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -35,20 +35,21 @@ source src {
 # https://www.syslog-ng.com/technical-documents/doc/\
 # syslog-ng-open-source-edition/3.19/administration-guide/53
 source mynetwork {
- tcp(
-  ip(0.0.0.0)
-  port(6514)
-  max-connections(300)
-  log-iw-size(30000)
-  so_keepalive(yes)
-  flags(no-multi-line)
-  tls(
-   key-file("/mnt/metricscerts/metrics.key")
-   cert-file("/mnt/metricscerts/metrics.crt")
-   ca-file("/mnt/metricscerts/ca_root.crt")
-   peer-verify(required-trusted)
-  )
- );
+  network(
+    ip(0.0.0.0)
+    port(6514)
+    transport(tls)
+    max-connections(300)
+    log-iw-size(30000)
+    so-keepalive(yes)
+    flags(no-multi-line)
+    tls(
+      key-file("/mnt/metricscerts/metrics.key")
+      cert-file("/mnt/metricscerts/metrics.crt")
+      ca-file("/mnt/metricscerts/ca_root.crt")
+      peer-verify(required-trusted)
+    )
+  );
 };
 
 # destinations
@@ -85,14 +86,17 @@ destination jsonmetricslog {
   );
 };
 destination loghost {
-  tcp("%%myip%%" port(6514)
-  tls(
-   key-file("/mnt/metricscerts/metrics.key")
-   cert-file("/mnt/metricscerts/metrics.crt")
-   ca-file("/mnt/metricscerts/ca_root.crt")
-   peer-verify(required-trusted)
-  )
- );
+  network(
+    "%%myip%%"
+    port(6514)
+    transport(tls)
+    tls(
+      key-file("/mnt/metricscerts/metrics.key")
+      cert-file("/mnt/metricscerts/metrics.crt")
+      ca-file("/mnt/metricscerts/ca_root.crt")
+      peer-verify(required-trusted)
+    )
+  );
 };
 
 # log facility filters

--- a/loki/loki.ini
+++ b/loki/loki.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="loki"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.3.6"
+version="0.3.7"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mailhub-potluck/CHANGELOG.md
+++ b/mailhub-potluck/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/mailhub-potluck/mailhub-potluck.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/mailhub-potluck/mailhub-potluck.d/local/share/cook/templates/syslog-ng.conf.in
@@ -4,16 +4,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,12 +43,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/mailhub-potluck/mailhub-potluck.ini
+++ b/mailhub-potluck/mailhub-potluck.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mailhub-potluck"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.18.2"
+version="0.18.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mariadb-galera/CHANGELOG.md
+++ b/mariadb-galera/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728)   # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/mariadb-galera/mariadb-galera.ini
+++ b/mariadb-galera/mariadb-galera.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb-galera"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.13.2"
+version="0.13.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
  
 ---
 

--- a/mariadb/mariadb.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/mariadb/mariadb.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/mariadb/mariadb.ini
+++ b/mariadb/mariadb.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="4.10.2"
+version="4.10.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mastodon-s3/CHANGELOG.md
+++ b/mastodon-s3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -47,12 +47,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/mastodon-s3/mastodon-s3.ini
+++ b/mastodon-s3/mastodon-s3.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mastodon-s3"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.16.2"
+version="0.16.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/matrix-synapse/CHANGELOG.md
+++ b/matrix-synapse/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -46,12 +46,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/matrix-synapse/matrix-synapse.ini
+++ b/matrix-synapse/matrix-synapse.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="matrix-synapse"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.10.2"
+version="2.10.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nextcloud-spreed-signalling/CHANGELOG.md
+++ b/nextcloud-spreed-signalling/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -46,12 +46,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-spreed-signalling"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.3.2"
+version="0.3.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-consul/CHANGELOG.md
+++ b/nginx-consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3.3
+
+* Update syslog-ng config to use modern config options
+
+---
+
 0.3.2
 
 * Enable milliseconds in syslog-ng for all log timestamps

--- a/nginx-consul/nginx-consul.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/nginx-consul/nginx-consul.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,9 +43,10 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(6514)
+    transport(tls)
     tls(
       key-file("/mnt/metricscerts/metrics.key")
       cert-file("/mnt/metricscerts/metrics.crt")
@@ -53,8 +54,9 @@ destination loghost {
       peer-verify(required-trusted)
     )
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/mnt/log/syslog-ng-disk-buffer")
     )

--- a/nginx-consul/nginx-consul.ini
+++ b/nginx-consul/nginx-consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-consul"
 author = "Michael Gmelin, Bretton Vine"
-version="0.3.2"
+version="0.3.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-rsync-ssh/CHANGELOG.md
+++ b/nginx-rsync-ssh/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/nginx-rsync-ssh/nginx-rsync-ssh.ini
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-rsync-ssh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.21.2"
+version="0.21.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nomad-server-tls/CHANGELOG.md
+++ b/nomad-server-tls/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.13.3
+
+* Update syslog-ng config to use modern config options
+
+---
+
 0.13.2
 
 * Enable milliseconds in syslog-ng for all log timestamps

--- a/nomad-server-tls/nomad-server-tls.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/nomad-server-tls/nomad-server-tls.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,9 +43,10 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(6514)
+    transport(tls)
     tls(
       key-file("/mnt/metricscerts/metrics.key")
       cert-file("/mnt/metricscerts/metrics.crt")
@@ -53,8 +54,9 @@ destination loghost {
       peer-verify(required-trusted)
     )
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/mnt/log/syslog-ng-disk-buffer")
     )

--- a/nomad-server-tls/nomad-server-tls.ini
+++ b/nomad-server-tls/nomad-server-tls.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nomad-server-tls"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.13.2"
+version="0.13.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nomad-server/CHANGELOG.md
+++ b/nomad-server/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/nomad-server/nomad-server.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/nomad-server/nomad-server.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/nomad-server/nomad-server.ini
+++ b/nomad-server/nomad-server.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nomad-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="3.22.2"
+version="3.22.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/openldap/CHANGELOG.md
+++ b/openldap/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/openldap/openldap.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/openldap/openldap.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -55,12 +55,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/openldap/openldap.ini
+++ b/openldap/openldap.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="openldap"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.23.2"
+version="1.23.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/opensearch/CHANGELOG.md
+++ b/opensearch/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/opensearch/opensearch.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/opensearch/opensearch.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -46,12 +46,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/opensearch/opensearch.ini
+++ b/opensearch/opensearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="opensearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.2"
+version="0.7.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/pixelfed/CHANGELOG.md
+++ b/pixelfed/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/pixelfed/pixelfed.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/pixelfed/pixelfed.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/pixelfed/pixelfed.ini
+++ b/pixelfed/pixelfed.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="pixelfed"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.2"
+version="0.7.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/postgres-single/CHANGELOG.md
+++ b/postgres-single/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/postgres-single/postgres-single.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/postgres-single/postgres-single.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/postgres-single/postgres-single.ini
+++ b/postgres-single/postgres-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postgres-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.12.2"
+version="0.12.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/postgresql-patroni/CHANGELOG.md
+++ b/postgresql-patroni/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.5.4
+
+* Update syslog-ng config to use modern config options
+
+---
+
 2.5.3
 
 * Enable milliseconds in syslog-ng for all log timestamps

--- a/postgresql-patroni/postgresql-patroni.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/postgresql-patroni/postgresql-patroni.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,9 +43,10 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(6514)
+    transport(tls)
     tls(
       key-file("/mnt/metricscerts/metrics.key")
       cert-file("/mnt/metricscerts/metrics.crt")
@@ -53,8 +54,9 @@ destination loghost {
       peer-verify(required-trusted)
     )
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/mnt/log/syslog-ng-disk-buffer")
     )

--- a/postgresql-patroni/postgresql-patroni.ini
+++ b/postgresql-patroni/postgresql-patroni.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postgresql-patroni"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.5.3"
+version="2.5.4"
 origin="freebsd"
 runs_in_nomad="false"

--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.16.3
+
+* Update syslog-ng config to use modern config options
+
+---
+
 0.16.2
 
 * Enable milliseconds in syslog-ng for all log timestamps

--- a/prometheus/prometheus.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/prometheus/prometheus.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,9 +43,10 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(6514)
+    transport(tls)
     tls(
       key-file("/mnt/metricscerts/metrics.key")
       cert-file("/mnt/metricscerts/metrics.crt")
@@ -53,8 +54,9 @@ destination loghost {
       peer-verify(required-trusted)
     )
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/mnt/log/syslog-ng-disk-buffer")
     )

--- a/prometheus/prometheus.ini
+++ b/prometheus/prometheus.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="prometheus"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.16.2"
+version="0.16.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/rbldnsd/CHANGELOG.md
+++ b/rbldnsd/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/rbldnsd/rbldnsd.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/rbldnsd/rbldnsd.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/rbldnsd/rbldnsd.ini
+++ b/rbldnsd/rbldnsd.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="rbldnsd"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.2"
+version="0.20.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/redis-single/CHANGELOG.md
+++ b/redis-single/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/redis-single/redis-single.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/redis-single/redis-single.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -46,12 +46,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/redis-single/redis-single.ini
+++ b/redis-single/redis-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="redis-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.12.2"
+version="0.12.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/saltstack/CHANGELOG.md
+++ b/saltstack/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/saltstack/saltstack.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/saltstack/saltstack.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/saltstack/saltstack.ini
+++ b/saltstack/saltstack.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="saltstack"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.2"
+version="0.20.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traefik-consul/CHANGELOG.md
+++ b/traefik-consul/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/traefik-consul/traefik-consul.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/traefik-consul/traefik-consul.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -50,12 +50,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/traefik-consul/traefik-consul.ini
+++ b/traefik-consul/traefik-consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traefik-consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.24.2"
+version="1.24.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traumadrill/CHANGELOG.md
+++ b/traumadrill/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/traumadrill/traumadrill.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/traumadrill/traumadrill.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -42,12 +42,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/traumadrill/traumadrill.ini
+++ b/traumadrill/traumadrill.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traumadrill"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.22.2"
+version="1.22.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/vault/CHANGELOG.md
+++ b/vault/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.5.3
+
+* Update syslog-ng config to use modern config options
+
+---
+
 2.5.2
 
 * Enable milliseconds in syslog-ng for all log timestamps

--- a/vault/vault.d/local/share/cook/templates/cluster-syslog-ng.conf.in
+++ b/vault/vault.d/local/share/cook/templates/cluster-syslog-ng.conf.in
@@ -3,17 +3,17 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- stats_freq(0);
- time_reopen(120);
- ts_format(iso);
+ stats(freq(0));
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -43,9 +43,10 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(6514)
+    transport(tls)
     tls(
       key-file("/mnt/metricscerts/metrics.key")
       cert-file("/mnt/metricscerts/metrics.crt")
@@ -53,8 +54,9 @@ destination loghost {
       peer-verify(required-trusted)
     )
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/mnt/log/syslog-ng-disk-buffer")
     )

--- a/vault/vault.ini
+++ b/vault/vault.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="vault"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.5.2"
+version="2.5.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/zincsearch/CHANGELOG.md
+++ b/zincsearch/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Enable milliseconds in syslog-ng for all log timestamps
+* Update syslog-ng config to use modern config options
 
 ---
 

--- a/zincsearch/zincsearch.d/local/share/cook/templates/syslog-ng.conf.in
+++ b/zincsearch/zincsearch.d/local/share/cook/templates/syslog-ng.conf.in
@@ -3,16 +3,16 @@
 
 # options
 options {
- chain_hostnames(off);
- use_dns (no);
+ chain-hostnames(no);
+ use-dns(no);
  dns-cache(no);
- use_fqdn (no);
- keep_hostname(no);
- flush_lines(0);
+ use-fqdn(no);
+ keep-hostname(no);
+ flush-lines(0);
  threaded(yes);
  log-fifo-size(2000);
- time_reopen(120);
- ts_format(iso);
+ time-reopen(120);
+ ts-format(iso);
  frac-digits(3);
 };
 
@@ -46,12 +46,14 @@ destination ppp { file("/var/log/ppp.log"); };
 destination allusers { usertty("*"); };
 # pot settings
 destination loghost {
-  tcp(
+  network(
     "%%remotelogip%%"
     port(514)
+    transport(tcp)
     disk-buffer(
-      mem-buf-size(134217728)   # 128MiB
-      disk-buf-size(2147483648) # 2GiB
+      truncate-size-ratio(1)
+      flow-control-window-bytes(134217728) # 128MiB
+      capacity-bytes(2147483648) # 2GiB
       reliable(yes)
       dir("/var/log/syslog-ng-disk-buffer")
     )

--- a/zincsearch/zincsearch.ini
+++ b/zincsearch/zincsearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="zincsearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.4.2"
+version="0.4.3"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
Hello, I was updating our internal syslog-ng configs since it would throw warnings about the format being "too old" and decided to also check the configs in potluck.

This PR makes these changes:
- Parameter names seem to have changed from underscores to dashes so updated the ones that still used underscores
- `tcp()` and `udp()` source/destination drivers are considered obsolete so I switched those to the `network()` driver
- `mem-buf-size()` is renamed to `flow-control-window-bytes()` since version 4.2
- `disk-buf-size()` is renamed to `capacity-bytes()` since version 4.2
- `stats-freq(0)` is now an option under the `stats()` group, fixes https://github.com/bsdpot/potluck/issues/49
- I have gotten a warning when starting syslog-ng that it can't switch to the new truncation logic since `truncate-size-ratio()` isn't set so I set it to `1`(no truncation) which is also the default

Functionally there should be no changes, this is more syntax changes.

@bretton I don't know if you want to rebuild haproxy and influxdb this time, I didn't bump the versions.