### PR TITLE
Version bump for rebuild

### DIFF
--- a/nextcloud-nginx-nomad/CHANGELOG.md
+++ b/nextcloud-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.109
+
+* Testing: remove special patches as post-install nextcloud integrity checker might be failing on the patches to add 'no ssl verify' for object storage
+
+---
+
 0.108
 
 * Fix php socket path for caddy

--- a/nextcloud-nginx-nomad/README.md
+++ b/nextcloud-nginx-nomad/README.md
@@ -231,7 +231,7 @@ The image boots with https enabled in nginx but serves over http only. You will 
 
 Pass in a ```ip:port``` parameter for ```SELFSIGNHOST``` or ```-s ip:port```. If you don't specify a port 443 will be used.
 
-You also need to copy-in the `rootca.crt` file created as part of setting up self-signed certificates. Make sure to copy-in to `/root/rootca.crt` as the script expecting this file name.
+You also need to copy-in the `rootca.crt` file created as part of setting up self-signed certificates. Make sure to copy-in to `/root/rootca.crt` as the script is expecting this file name.
 
 ## Use Caddy instead of NGINX
 

--- a/nextcloud-nginx-nomad/README.md
+++ b/nextcloud-nginx-nomad/README.md
@@ -194,7 +194,7 @@ job "nextcloud" {
       config {
         image = "https://potluck.honeyguide.net/nextcloud-nginx-nomad"
         pot = "nextcloud-nginx-nomad-amd64-14_1"
-        tag = "0.108"
+        tag = "0.109"
         command = "/usr/local/bin/cook"
         args = ["-d","/mnt/filestore","-s","host:ip"]
         copy = [

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-nextcloud.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-nextcloud.sh
@@ -56,29 +56,29 @@ if [ -n "${SELFSIGNHOST}" ]; then
         cat /root/rootca.crt >> /usr/local/www/nextcloud/resources/config/ca-bundle.crt
     fi
 
-    if [ -n "${SPECIALPATCH}" ]; then
-        # Patch nextcloud source for self-signed certificates with S3
-        if [ -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php ] && [ -f "$TEMPLATEPATH/S3ObjectTrait.patch" ]; then
-            # make sure we haven't already applied the patch
-            checknotapplied=$(grep -c verify_peer_name /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php)
-            if [ "${checknotapplied}" -eq 0 ]; then
-                # check the patch will apply cleanly
-                # shellcheck disable=SC2008
-                testpatch=$(patch --check -i "$TEMPLATEPATH/S3ObjectTrait.patch" /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php | echo "$?")
-                if [ "${testpatch}" -eq 0 ]; then
-                    # apply the patch
-                    patch -i "$TEMPLATEPATH/S3ObjectTrait.patch" /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php
-                fi
-            fi
-        fi
-    else
-        if [ -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php ] && [ -f "$TEMPLATEPATH/nosslverify.patch" ]; then
-            if [ ! -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php.patched ]; then
-                cp "$TEMPLATEPATH/nosslverify.patch" /usr/local/www/nextcloud/lib/private/Files/ObjectStore/nosslverify.patch
-                sed -e "/'cafile' => \$bundle/r /usr/local/www/nextcloud/lib/private/Files/ObjectStore/nosslverify.patch" -e "//d" /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php > /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php.patched
-                cp -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php.original
-                cp -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php.patched /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php
-            fi
-        fi
-    fi
+    # if [ -n "${SPECIALPATCH}" ]; then
+    #     # Patch nextcloud source for self-signed certificates with S3
+    #     if [ -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php ] && [ -f "$TEMPLATEPATH/S3ObjectTrait.patch" ]; then
+    #         # make sure we haven't already applied the patch
+    #         checknotapplied=$(grep -c verify_peer_name /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php)
+    #         if [ "${checknotapplied}" -eq 0 ]; then
+    #             # check the patch will apply cleanly
+    #             # shellcheck disable=SC2008
+    #             testpatch=$(patch --check -i "$TEMPLATEPATH/S3ObjectTrait.patch" /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php | echo "$?")
+    #             if [ "${testpatch}" -eq 0 ]; then
+    #                 # apply the patch
+    #                 patch -i "$TEMPLATEPATH/S3ObjectTrait.patch" /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php
+    #             fi
+    #         fi
+    #     fi
+    # else
+    #     if [ -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php ] && [ -f "$TEMPLATEPATH/nosslverify.patch" ]; then
+    #         if [ ! -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php.patched ]; then
+    #             cp "$TEMPLATEPATH/nosslverify.patch" /usr/local/www/nextcloud/lib/private/Files/ObjectStore/nosslverify.patch
+    #             sed -e "/'cafile' => \$bundle/r /usr/local/www/nextcloud/lib/private/Files/ObjectStore/nosslverify.patch" -e "//d" /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php > /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php.patched
+    #             cp -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php.original
+    #             cp -f /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php.patched /usr/local/www/nextcloud/lib/private/Files/ObjectStore/S3ObjectTrait.php
+    #         fi
+    #     fi
+    # fi
 fi

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.108"
+version="0.109"
 origin="freebsd"
 runs_in_nomad="true"


### PR DESCRIPTION
Testing: remove special patches as post-install nextcloud integrity checker might be failing on the patches to add 'no ssl verify' for object storage