### PR TITLE
Mass update with version bump for 14.2 or to use base image 14.2

### DIFF
--- a/adminer/CHANGELOG.md
+++ b/adminer/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.10
+
+* Version bump for new base image 14.2
+
+---
+
 0.9
 
 * Version bump for new base image

--- a/adminer/adminer.ini
+++ b/adminer/adminer.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="adminer"
 author="Deividas Gedgaudas"
-version="0.9.3"
+version="0.10.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/backuppc-nomad/CHANGELOG.md
+++ b/backuppc-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.19
+
+* Version bump for new base image 14.2
+
+--- 
+
 1.18
 
 * Version bump for new base image

--- a/backuppc-nomad/README.md
+++ b/backuppc-nomad/README.md
@@ -63,8 +63,8 @@ job "backuppc" {
 
       config {
         image = "https://potluck.honeyguide.net/backuppc-nomad"
-        pot = "backuppc-nomad-amd64-14_1"
-        tag = "1.18.1"
+        pot = "backuppc-nomad-amd64-14_2"
+        tag = "1.19.1"
         command = "/usr/local/bin/cook"
         args = ["-p","myadminpassword"]
         mount = [

--- a/backuppc-nomad/backuppc-nomad.ini
+++ b/backuppc-nomad/backuppc-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="backuppc-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.18.1"
+version="1.19.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/beast-of-argh/CHANGELOG.md
+++ b/beast-of-argh/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.23
+
+* Version bump for new base image 14.2
+
+---
+
 0.22
 
 * Version bump for new base image

--- a/beast-of-argh/beast-of-argh.ini
+++ b/beast-of-argh/beast-of-argh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="beast-of-argh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.22.3"
+version="0.23.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/caddy-s3-nomad/CHANGELOG.md
+++ b/caddy-s3-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.16
+
+* Version bump for new base image 14.2
+
+---
+
 0.15
 
 * Version bump for new base image

--- a/caddy-s3-nomad/CHECKLIST.md
+++ b/caddy-s3-nomad/CHECKLIST.md
@@ -26,7 +26,7 @@ When `go` version changes updated the package install line and git sparse checko
 ## Quarterly Package Updates
 Every new quarterly pkg release, update this line to next applicable quarter
 ```
-git pull --depth=1 origin 2024Q3
+git pull --depth=1 origin 2024Q4
 ```
 in:
 * `caddy-s3-nomad.sh`

--- a/caddy-s3-nomad/README.md
+++ b/caddy-s3-nomad/README.md
@@ -97,8 +97,8 @@ job "example" {
 
       config {
         image = "https://potluck.honeyguide.net/caddy-s3-nomad"
-        pot = "caddy-s3-nomad-amd64-14_1"
-        tag = "0.15.1"
+        pot = "caddy-s3-nomad-amd64-14_2"
+        tag = "0.16.1"
         command = "/usr/local/bin/cook"
         args = ["-h","s3.my.host","-b","bucketname","-d","domainname","-e","email@add.com","-s","yes"]
 		mount = [

--- a/caddy-s3-nomad/caddy-s3-nomad.ini
+++ b/caddy-s3-nomad/caddy-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="caddy-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.15.1"
+version="0.16.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/caddy-s3-nomad/caddy-s3-nomad.sh
+++ b/caddy-s3-nomad/caddy-s3-nomad.sh
@@ -181,7 +181,7 @@ git sparse-checkout set GIDs UIDs \
 step "Pull files"
 #git pull --depth=1 origin 2023Q3
 #git pull --depth=1 origin 2024Q2
-git pull --depth=1 origin 2024Q3
+git pull --depth=1 origin 2024Q4
 
 # go straight to building caddy-custom
 #step "Build caddy"

--- a/consul-tls/CHANGELOG.md
+++ b/consul-tls/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.6
+
+* Version bump for new base image 14.2
+
+---
+
 0.5
 
 * Version bump for new base image 14.1

--- a/consul-tls/consul-tls.ini
+++ b/consul-tls/consul-tls.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="consul-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.5.3"
+version="0.6.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.22
+
+* Version bump for new base image 14.2
+
+---
+
 2.21
 
 * Version bump for new base image

--- a/consul/consul.ini
+++ b/consul/consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.21.3"
+version="2.22.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/dmarc-report/CHANGELOG.md
+++ b/dmarc-report/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.18
+
+* Version bump for new base image 14.2
+
+---
+
 0.17
 
 * Version bump for new base image

--- a/dmarc-report/dmarc-report.ini
+++ b/dmarc-report/dmarc-report.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="dmarc-report"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.17.3"
+version="0.18.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/git-nomad/CHANGELOG.md
+++ b/git-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.21
+
+* Version bump for new base image 14.2
+  
+---
+
 1.20
 
 * Version bump for new base image

--- a/git-nomad/README.md
+++ b/git-nomad/README.md
@@ -52,8 +52,8 @@ job "examplegit" {
 
       config {
         image = "https://potluck.honeyguide.net/git-nomad"
-        pot = "git-nomad-amd64-14_1"
-        tag = "1.20.1"
+        pot = "git-nomad-amd64-14_2"
+        tag = "1.21.1"
         command = "/usr/local/bin/cook"
         args = ["-n","gitnomad"]
 

--- a/git-nomad/git-nomad.ini
+++ b/git-nomad/git-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="git-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.20.1"
+version="1.21.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/grafana/CHANGELOG.md
+++ b/grafana/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.8
+
+* Version bump for new base image 14.2
+
+---
+
 0.7.3
 
 * Update syslog-ng config to use modern config options

--- a/grafana/grafana.ini
+++ b/grafana/grafana.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="grafana"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.3"
+version="0.8.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy-consul/CHANGELOG.md
+++ b/haproxy-consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.4
+
+* Version bump for new base image 14.2
+
+---
+
 0.3.3
 
 * Update syslog-ng config to use modern config options

--- a/haproxy-consul/haproxy-consul.ini
+++ b/haproxy-consul/haproxy-consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-consul"
 author = "Michael Gmelin, Bretton Vine"
-version="0.3.3"
+version="0.4.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy-minio/CHANGELOG.md
+++ b/haproxy-minio/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.10
+
+* Version bump for new base image 14.2
+  
+---
+
 0.9
 
 * Version bump for new base image

--- a/haproxy-minio/haproxy-minio.ini
+++ b/haproxy-minio/haproxy-minio.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-minio"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.9.3"
+version="0.10.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy-sql/CHANGELOG.md
+++ b/haproxy-sql/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.15
+
+* Version bump for new base image 14.2
+  
+---
+
 0.14
 
 * Version bump for new base image

--- a/haproxy-sql/haproxy-sql.ini
+++ b/haproxy-sql/haproxy-sql.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-sql"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.14.3"
+version="0.15.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/hugo-nginx-alt/CHANGELOG.md
+++ b/hugo-nginx-alt/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.10
+
+* Version bump for new base image 14.2
+
+---
+
 0.9
 
 * Version bump for new base image

--- a/hugo-nginx-alt/hugo-nginx-alt.ini
+++ b/hugo-nginx-alt/hugo-nginx-alt.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx-alt"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.9.3"
+version="0.10.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/hugo-nginx/CHANGELOG.md
+++ b/hugo-nginx/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.21
+
+* Version bump for new base image 14.2
+
+---
+
 0.20
 
 * Version bump for new base image

--- a/hugo-nginx/hugo-nginx.ini
+++ b/hugo-nginx/hugo-nginx.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.3"
+version="0.21.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/jenkins/CHANGELOG.md
+++ b/jenkins/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.21
+
+* Version bump for new base image 14.2
+
+---
+
 0.20
 
 * Version bump for new base image

--- a/jenkins/jenkins.ini
+++ b/jenkins/jenkins.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="jenkins"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.3"
+version="0.21.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/loki/CHANGELOG.md
+++ b/loki/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.4
+
+* Version bump for new base image 14.2
+
+---
+
 0.3.7
 
 * Update syslog-ng config to use modern config options

--- a/loki/loki.ini
+++ b/loki/loki.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="loki"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.3.7"
+version="0.4.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mailhub-potluck/CHANGELOG.md
+++ b/mailhub-potluck/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.19
+
+* Version bump for new base image 14.2
+
+---
+
 0.18
 
 * Version bump for new base image

--- a/mailhub-potluck/mailhub-potluck.ini
+++ b/mailhub-potluck/mailhub-potluck.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mailhub-potluck"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.18.3"
+version="0.19.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mailhub-potluck/mailhub-potluck.sh
+++ b/mailhub-potluck/mailhub-potluck.sh
@@ -250,7 +250,7 @@ git sparse-checkout set GIDs UIDs \
   mail/dovecot/ \
   mail/dovecot-pigeonhole/ \
   mail/spamassassin/ \
-  lang/python39/ \
+  lang/python311/ \
   ports-mgmt/pkg/ \
   converters/p5-Encode-Detect/ \
   converters/libiconv/ \

--- a/mariadb-galera/CHANGELOG.md
+++ b/mariadb-galera/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.14
+
+* Version bump for new base image 14.2
+
+---
+
 0.13
 
 * Version bump for new base image

--- a/mariadb-galera/mariadb-galera.ini
+++ b/mariadb-galera/mariadb-galera.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb-galera"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.13.4"
+version="0.14.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,3 +1,9 @@
+4.11
+
+* Version bump for new base image 14.2
+
+---
+
 4.10
 
 * Version bump for new base image

--- a/mariadb/mariadb.ini
+++ b/mariadb/mariadb.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="4.10.4"
+version="4.11.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mastodon-s3/CHANGELOG.md
+++ b/mastodon-s3/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.17
+
+* Version bump for 14.2
+* New version mastodon 4.3.2
+
+---
+
 0.16
 
 * Version bump for new image

--- a/mastodon-s3/mastodon-s3.ini
+++ b/mastodon-s3/mastodon-s3.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mastodon-s3"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.16.3"
+version="0.17.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mastodon-s3/mastodon-s3.sh
+++ b/mastodon-s3/mastodon-s3.sh
@@ -300,7 +300,8 @@ if [ ! -d /usr/local/www/mastodon/.git ]; then
     #su - mastodon -c "cd /usr/local/www/mastodon; git checkout 092506c90f976e13a7a99754d78c08d296b1bc84"
     #su - mastodon -c "cd /usr/local/www/mastodon; git checkout 86a7596a40f086196fdd288ffdf4614a57af6513"
     #su - mastodon -c "cd /usr/local/www/mastodon; git checkout 11aaee1eca898184c871fe5448f7cd6e7e96d156"
-    su - mastodon -c "cd /usr/local/www/mastodon; git checkout 460e86f8410ae671e275e35a5fbb82b98030773b"
+    #su - mastodon -c "cd /usr/local/www/mastodon; git checkout 460e86f8410ae671e275e35a5fbb82b98030773b"
+    su - mastodon -c "cd /usr/local/www/mastodon; git checkout 1506ed6009476f793015d6bbcfc4283d09a79d75"
 else
     echo ".git directory exists, not cloning repo"
 fi

--- a/matrix-synapse/CHANGELOG.md
+++ b/matrix-synapse/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.11
+
+* Version bump for new base image 14.2
+
+---
+
 2.10
 
 * Version bump for new base image

--- a/matrix-synapse/matrix-synapse.ini
+++ b/matrix-synapse/matrix-synapse.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="matrix-synapse"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.10.3"
+version="2.11.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nextcloud-nginx-nomad/CHANGELOG.md
+++ b/nextcloud-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.110
+
+* Rebuild for 14.2
+
+---
+
 0.109
 
 * Testing: remove special patches as post-install nextcloud integrity checker might be failing on the patches to add 'no ssl verify' for object storage

--- a/nextcloud-nginx-nomad/README.md
+++ b/nextcloud-nginx-nomad/README.md
@@ -193,8 +193,8 @@ job "nextcloud" {
 
       config {
         image = "https://potluck.honeyguide.net/nextcloud-nginx-nomad"
-        pot = "nextcloud-nginx-nomad-amd64-14_1"
-        tag = "0.109"
+        pot = "nextcloud-nginx-nomad-amd64-14_2"
+        tag = "0.110"
         command = "/usr/local/bin/cook"
         args = ["-d","/mnt/filestore","-s","host:ip"]
         copy = [

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.109"
+version="0.110"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nextcloud-spreed-signalling/CHANGELOG.md
+++ b/nextcloud-spreed-signalling/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.4
+
+* Version bump for new base image 14.2
+
+---
+
 0.3
 
 * Version bump for new base image

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-spreed-signalling"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.3.3"
+version="0.4.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-consul/CHANGELOG.md
+++ b/nginx-consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.4
+
+* Version bump for new base image 14.2
+
+---
+
 0.3.3
 
 * Update syslog-ng config to use modern config options

--- a/nginx-consul/nginx-consul.ini
+++ b/nginx-consul/nginx-consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-consul"
 author = "Michael Gmelin, Bretton Vine"
-version="0.3.3"
+version="0.4.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-nomad-alt/CHANGELOG.md
+++ b/nginx-nomad-alt/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.20
+
+* Version bump for new base image 14.2
+
+---
+
 0.19
 
 * Version bump for new base image

--- a/nginx-nomad-alt/README.md
+++ b/nginx-nomad-alt/README.md
@@ -62,8 +62,8 @@ job "example" {
 
       config {
         image = "https://potluck.honeyguide.net/nginx-nomad-alt"
-        pot = "nginx-nomad-alt-amd64-14_1"
-        tag = "0.19.1"
+        pot = "nginx-nomad-alt-amd64-14_2"
+        tag = "0.20.1"
         command = "/usr/local/bin/cook"
         args = ["-s","servername"]
         mount = [

--- a/nginx-nomad-alt/nginx-nomad-alt.ini
+++ b/nginx-nomad-alt/nginx-nomad-alt.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-nomad-alt"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.19.1"
+version="0.20.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-rsync-ssh/CHANGELOG.md
+++ b/nginx-rsync-ssh/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.22
+
+* Version bump for new base image 14.2
+
+---
+
 0.21
 
 * Version bump for new base image

--- a/nginx-rsync-ssh/nginx-rsync-ssh.ini
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-rsync-ssh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.21.3"
+version="0.22.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-s3-nomad/CHANGELOG.md
+++ b/nginx-s3-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.22
+
+* Version bump for new base image 14.2
+
+---
+
 0.21
 
 * Version bump for new base image

--- a/nginx-s3-nomad/README.md
+++ b/nginx-s3-nomad/README.md
@@ -95,8 +95,8 @@ job "example" {
 
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
-        pot = "nginx-s3-nomad-amd64-14_1"
-        tag = "0.21.1"
+        pot = "nginx-s3-nomad-amd64-14_2"
+        tag = "0.22.1"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-x","bucketname","-s","yes"]
         port_map = {
@@ -149,8 +149,8 @@ job "example" {
 
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
-        pot = "nginx-s3-nomad-amd64-14_1"
-        tag = "0.21.1"
+        pot = "nginx-s3-nomad-amd64-14_2"
+        tag = "0.22.1"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-c","10.0.0.4","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-nomad/nginx-s3-nomad.ini
+++ b/nginx-s3-nomad/nginx-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.21.1"
+version="0.22.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-s3-ssl-nomad/CHANGELOG.md
+++ b/nginx-s3-ssl-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.11
+
+* Version bump for new base image 14.2
+
+---
+
 0.10
 
 * Version bump for new base image

--- a/nginx-s3-ssl-nomad/README.md
+++ b/nginx-s3-ssl-nomad/README.md
@@ -97,8 +97,8 @@ job "example" {
 
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
-        pot = "nginx-s3-ssl-nomad-amd64-14_1"
-        tag = "0.10.1"
+        pot = "nginx-s3-ssl-nomad-amd64-14_2"
+        tag = "0.11.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -151,8 +151,8 @@ job "example" {
 
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
-        pot = "nginx-s3-ssl-nomad-amd64-14_1"
-        tag = "0.10.1"
+        pot = "nginx-s3-ssl-nomad-amd64-14_2"
+        tag = "0.11.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -205,8 +205,8 @@ job "example" {
 
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
-        pot = "nginx-s3-ssl-nomad-amd64-14_1"
-        tag = "0.10.1"
+        pot = "nginx-s3-ssl-nomad-amd64-14_2"
+        tag = "0.11.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-g","10.0.0.4:9000","-h","10.0.0.5:9000","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.10.1"
+version="0.11.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-varnish-ssl-nomad/CHANGELOG.md
+++ b/nginx-varnish-ssl-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.2
+
+* Version bump for new base image 14.2
+
+---
+
 0.1
 
 * Version bump for new base image

--- a/nginx-varnish-ssl-nomad/README.md
+++ b/nginx-varnish-ssl-nomad/README.md
@@ -68,8 +68,8 @@ job "example" {
 
       config {
         image = "https://potluck.honeyguide.net/nginx-varnish-ssl-nomad"
-        pot = "nginx-varnish-ssl-nomad-amd64-14_1"
-        tag = "0.1.1"
+        pot = "nginx-varnish-ssl-nomad-amd64-14_2"
+        tag = "0.2.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-s","10.0.0.2:8080","-b","bucketname"]
         port_map = {

--- a/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
+++ b/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-varnish-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.1.1"
+version="0.2.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nomad-server-tls/CHANGELOG.md
+++ b/nomad-server-tls/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.14
+
+* Version bump for new base image 14.2
+
+---
+
 0.13.3
 
 * Update syslog-ng config to use modern config options

--- a/nomad-server-tls/nomad-server-tls.ini
+++ b/nomad-server-tls/nomad-server-tls.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nomad-server-tls"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.13.3"
+version="0.14.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nomad-server/CHANGELOG.md
+++ b/nomad-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.23
+
+* Version bump for new base image 14.2
+
+---
+
 3.22
 
 * Version bump for new base image

--- a/nomad-server/nomad-server.ini
+++ b/nomad-server/nomad-server.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nomad-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="3.22.3"
+version="3.23.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/openldap/CHANGELOG.md
+++ b/openldap/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.24
+
+* Version bump for new base image 14.2
+
+---
+
 1.23
 
 * Version bump for new base image

--- a/openldap/openldap.ini
+++ b/openldap/openldap.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="openldap"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.23.3"
+version="1.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/opensearch/CHANGELOG.md
+++ b/opensearch/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.8
+
+* Version bump for new base image 14.2
+
+---
+
 0.7
 
 * Version bump for new base image

--- a/opensearch/opensearch.ini
+++ b/opensearch/opensearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="opensearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.3"
+version="0.8.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/pixelfed/CHANGELOG.md
+++ b/pixelfed/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.8
+
+* Version bump for new base image 14.2
+
+---
+
 0.7
 
 * Version bump for new base image

--- a/pixelfed/pixelfed.ini
+++ b/pixelfed/pixelfed.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="pixelfed"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.3"
+version="0.8.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/postfix-backupmx-nomad/CHANGELOG.md
+++ b/postfix-backupmx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.19
+
+* Version bump for new base image 14.2
+
+---
+
 1.18
 
 * Version bump for new base image

--- a/postfix-backupmx-nomad/README.md
+++ b/postfix-backupmx-nomad/README.md
@@ -53,8 +53,8 @@ job "backupmx" {
 
       config {
         image = "https://potluck.honeyguide.net/postfix-backupmx-nomad"
-        pot = "postfix-backupmx-nomad-amd64-14_1"
-        tag = "1.18.1"
+        pot = "postfix-backupmx-nomad-amd64-14_2"
+        tag = "1.19.1"
         command = "/usr/local/bin/cook"
         args = ["-n","10.10.10.10/32","-d","'example1.com, example2.com, example.de'","-b","'mx2.example1.com ESMTP \\$mail_name'","-h","mx2.example1.com"]
         mount = [
@@ -116,8 +116,8 @@ job "backupmx" {
        }
        config {
         image = "https://potluck.honeyguide.net/postfix-backupmx-nomad"
-        pot = "postfix-backupmx-nomad-amd64-14_1"
-        tag = "1.18.1"
+        pot = "postfix-backupmx-nomad-amd64-14_2"
+        tag = "1.19.1"
         command = "/usr/local/bin/cook"
         args = [""]
 

--- a/postfix-backupmx-nomad/postfix-backupmx-nomad.ini
+++ b/postfix-backupmx-nomad/postfix-backupmx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postfix-backupmx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.18.1"
+version="1.19.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/postgres-single/CHANGELOG.md
+++ b/postgres-single/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.13
+
+* Version bump for new base image 14.2
+
+---
+
 0.12
 
 * Version bump for new base image

--- a/postgres-single/postgres-single.ini
+++ b/postgres-single/postgres-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postgres-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.12.3"
+version="0.13.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/postgresql-patroni/CHANGELOG.md
+++ b/postgresql-patroni/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.6
+
+* Version bump for new base image 14.2
+
+---
+
 2.5.4
 
 * Update syslog-ng config to use modern config options

--- a/postgresql-patroni/postgresql-patroni.ini
+++ b/postgresql-patroni/postgresql-patroni.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postgresql-patroni"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.5.4"
+version="2.6.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/prometheus/CHANGELOG.md
+++ b/prometheus/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.17
+
+* Version bump for new base image 14.2
+
+---
+
 0.16.3
 
 * Update syslog-ng config to use modern config options

--- a/prometheus/prometheus.ini
+++ b/prometheus/prometheus.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="prometheus"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.16.3"
+version="0.17.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/rbldnsd/CHANGELOG.md
+++ b/rbldnsd/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.21
+
+* Version bump for new base image 14.2
+
+---
+
 0.20
 
 * Version bump for new base image

--- a/rbldnsd/rbldnsd.ini
+++ b/rbldnsd/rbldnsd.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="rbldnsd"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.3"
+version="0.21.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/redis-single/CHANGELOG.md
+++ b/redis-single/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.13
+
+* Version bump for new base image 14.2
+
+---
+
 0.12
 
 * Version bump for new base image

--- a/redis-single/redis-single.ini
+++ b/redis-single/redis-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="redis-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.12.3"
+version="0.13.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/saltstack/CHANGELOG.md
+++ b/saltstack/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.21
+
+* Version bump for new base image 14.2
+
+---
+
 0.20
 
 * Version bump for new base image

--- a/saltstack/saltstack.ini
+++ b/saltstack/saltstack.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="saltstack"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.3"
+version="0.21.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traefik-consul/CHANGELOG.md
+++ b/traefik-consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.25
+
+* Version bump for new base image 14.2
+
+---
+
 1.24
 
 * Version bump for new base image

--- a/traefik-consul/traefik-consul.ini
+++ b/traefik-consul/traefik-consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traefik-consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.24.3"
+version="1.25.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traumadrill/CHANGELOG.md
+++ b/traumadrill/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.23
+
+* Version bump for new base image 14.2
+
+---
+
 1.22
 
 * Version bump for new base image

--- a/traumadrill/traumadrill.ini
+++ b/traumadrill/traumadrill.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traumadrill"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.22.3"
+version="1.23.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/vault/CHANGELOG.md
+++ b/vault/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.6
+
+* Version bump for new base image 14.2
+
+---
+
 2.5.3
 
 * Update syslog-ng config to use modern config options

--- a/vault/vault.ini
+++ b/vault/vault.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="vault"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.5.3"
+version="2.6.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/wordpress-nginx-nomad/CHANGELOG.md
+++ b/wordpress-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.19
+
+* Version bump for new base image 14.2
+
+---
+
 2.18
 
 * Version bump for new base image

--- a/wordpress-nginx-nomad/README.md
+++ b/wordpress-nginx-nomad/README.md
@@ -58,8 +58,8 @@ job "example" {
 
       config {
         image = "https://potluck.honeyguide.net/wordpress-nginx-nomad"
-        pot = "wordpress-nginx-nomad-amd64-14_1"
-        tag = "2.18.1"
+        pot = "wordpress-nginx-nomad-amd64-14_2"
+        tag = "2.19.1"
         command = "/usr/local/bin/cook"
         args = [""]
         mount = [

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="wordpress-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.18.1"
+version="2.19.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/zincsearch/CHANGELOG.md
+++ b/zincsearch/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.5
+
+* Version bump for new base image 14.2
+* Use correct download link from github
+
+---
+
 0.4
 
 * Version bump for new base image

--- a/zincsearch/zincsearch.ini
+++ b/zincsearch/zincsearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="zincsearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.4.3"
+version="0.5.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/zincsearch/zincsearch.sh
+++ b/zincsearch/zincsearch.sh
@@ -132,7 +132,7 @@ pkg clean -y
 
 step "Download and extract zincsearch binary from github"
 fetch -qo - \
- https://github.com/zincsearch/zincsearch/releases/download/v0.4.10/zincsearch_0.4.10_darwin_x86_64.tar.gz | \
+ https://github.com/zincsearch/zincsearch/releases/download/v0.4.10/zincsearch_0.4.10_freebsd_x86_64.tar.gz | \
  tar xzf - -C /usr/local/bin
 
 step "Testing if zincsearch binary exists"
@@ -142,7 +142,7 @@ fi
 
 step "Checksum query for zincsearch"
 if [ "$(sha256 -q /usr/local/bin/zincsearch)" != \
-  "aa64596e4660e95adee12d996892b4bcfedc3c52ab110f0f3804ba87569375c6" ]; then
+  "ebe143482d6bf95b966daa51a8360af7e20e9162b2e1db8f1685924226aa2b9f" ]; then
   exit_error "/usr/local/bin/zincsearch checksum mismatch!"
 fi
 


### PR DESCRIPTION
Mass update with version bump for 14.2 or to use base image 14.2

New version mastodon 4.3.2

Corrected zincsearch download link