### PR TITLE
Netbox: version bump for rebuild

### DIFF
--- a/netbox/CHANGELOG.md
+++ b/netbox/CHANGELOG.md
@@ -18,3 +18,6 @@
 * Adjust service start order to start nginx last
 * Fix remaining configuration.py.in typos
 * Upgrade steps are not conditional, static files for site need to be generated every time
+* Switch to using nginx with SSL, either via self-signed certificate, or acme.sh registration. Add renew script.
+* Set media location in mount in storage
+* Clean up CHECKLIST

--- a/netbox/CHECKLIST.md
+++ b/netbox/CHECKLIST.md
@@ -26,14 +26,5 @@ Changes in python version need updating of `/usr/local/bin/python3.11` in the fo
 * `netbox.d/local/share/cook/bin/check-upgrade.sh`
 * `netbox.d/local/share/cook/templates/850.netbox-housekeeping.in`
 
-## Postgresql upgrades
-This image has postgresql v16 installed and configured to store data in `/mnt/postgres/data/16/`.
-
-For postgresql v17 and automatic upgrades, update pkg names, paths and values in
-* `netbox.sh`
-* `netbox.d/local/share/cook/bin/configure-postgres.sh`
-
-There is no way to automatically upgrade old versions of the database without having binaries for old and new versions installed, so it's better to dump a backup and import to new setup.
-
 ## Shellcheck
 Was `shellcheck` run on all applicable shell files?

--- a/netbox/README.md
+++ b/netbox/README.md
@@ -113,7 +113,7 @@ MAILPORT is an optional parameter that can be set if the default SMTP port diffe
 
 REDISPORT is an optional parameter that can be set if the default redis port differs from port 6379.
 
-PVTCERT is an optional parameter to make use of self-signed SSL certificates instead of acme.sh for registation. Use this is your frontend proxy does SSL already.
+PVTCERT is an optional parameter to make use of self-signed SSL certificates instead of acme.sh for registation. Use this if your frontend proxy does SSL already.
 
 CERTEMAIL is an optional parameter to set a custom email address for acme.sh certificate registrations. If not set, ADMINEMAIL is used instead.
 

--- a/netbox/README.md
+++ b/netbox/README.md
@@ -64,6 +64,8 @@ You will also need a redis pot jail dedicated to netbox, as two databases are us
     [ -E DBPORT=<postgresql port> ] \
     [ -E REDISPORT=<redis port> ] \
     [ -E MAILPORT=<SMTP port> ] \
+    [ -E PVTCERT=<any value enables self-signed SSL certificate> ] \
+    [ -E CERTEMAIL=<email address for acme.sh certificate registration> ] \
     [ -E REMOTELOG=<IP address> ]
   ```
 * Start the jail
@@ -99,7 +101,7 @@ The FROMMAIL parameter is the sender address to use for the SMTP server.
 
 The ADMINNAME parameter is the name of the netbox superuser account. It could be a user, or Administrator.
 
-The ADMINEMAIL parameter is the notification address of the superuser account, to send notices to.
+The ADMINEMAIL parameter is the email address of the superuser account, also used for system notifications.
 
 The ADMINPASSWORD parameter is the password for the superuser account.
 
@@ -110,6 +112,10 @@ DBPORT is an optional parameter that can be set if the default database port dif
 MAILPORT is an optional parameter that can be set if the default SMTP port differs from port 25.
 
 REDISPORT is an optional parameter that can be set if the default redis port differs from port 6379.
+
+PVTCERT is an optional parameter to make use of self-signed SSL certificates instead of acme.sh for registation. Use this is your frontend proxy does SSL already.
+
+CERTEMAIL is an optional parameter to set a custom email address for acme.sh certificate registrations. If not set, ADMINEMAIL is used instead.
 
 The REMOTELOG parameter is the IP address of a destination ```syslog-ng``` server, such as with the ```loki``` flavour, or ```beast-of-argh``` flavour.
 

--- a/netbox/netbox.d/local/bin/cook
+++ b/netbox/netbox.d/local/bin/cook
@@ -54,6 +54,7 @@ required_args="$required_args DBHOST DBNAME DBUSER DBPASSWORD REDISHOST"
 required_args="$required_args MAILSERVER MAILUSERNAME MAILPASSWORD"
 required_args="$required_args ADMINNAME ADMINEMAIL ADMINPASSWORD FROMMAIL"
 optional_args="REMOTELOG DISABLEUNBOUNDV6 DBPORT REDISPORT MAILPORT"
+optional_args="$optional_args PVTCERT CERTEMAIL"
 
 for var in $required_args; do
   if [ -z "$(eval echo "\${$var}")" ]; then
@@ -107,6 +108,14 @@ else
 	export SETMAILPORT
 fi
 
+if [ -n "${CERTEMAIL+x}" ]; then
+	SETCERTEMAIL="$CERTEMAIL"
+	export SETCERTEMAIL
+else
+	SETCERTEMAIL="$ADMINEMAIL"
+	export SETCERTEMAIL
+fi
+
 # stop services
 timeout --foreground 10 \
   service consul onestop || service consul onestop || true
@@ -139,6 +148,14 @@ timeout --foreground 120 \
 
 log "Start node_exporter"
 service node_exporter start
+
+if [ -n "${PVTCERT}" ]; then
+	log "Configure ssl"
+	configure-ssl.sh
+else
+	log "Configure acme.sh"
+	configure-acme.sh
+fi
 
 log "Configure nginx"
 configure-nginx.sh

--- a/netbox/netbox.d/local/share/cook/bin/configure-acme.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-acme.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+if [ -e /root/.env.cook ]; then
+	. /root/.env.cook
+fi
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+# shellcheck disable=SC2086
+export PATH=/usr/local/bin:$PATH
+
+SCRIPT=$(readlink -f "$0")
+TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
+
+# make directories if they don't exist
+mkdir -p /mnt/acme
+mkdir -p /root/bin
+mkdir -p /usr/local/www/acmetmp/
+
+# the following is required for option --set-default-ca
+mkdir -p /root/.acme.sh/
+touch /root/.acme.sh/account.conf
+
+# shellcheck disable=SC3003,SC2039
+# safe(r) separator for sed
+sep=$'\001'
+
+# copy over script for cronjob
+< "$TEMPLATEPATH/update-certs.sh.in" \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" | \
+  sed "s${sep}%%email%%${sep}$SETCERTEMAIL${sep}g" \
+  > /root/bin/update-certs.sh
+
+# set perms
+chmod 750 /root/bin/update-certs.sh
+
+# check if existing $DOMAIN and create certificates if not
+if [ ! -d /mnt/acme/"$DOMAIN"_ecc/ ]; then
+	/usr/local/sbin/acme.sh --register-account -m "$SETCERTEMAIL" --home /mnt/acme --server letsencrypt
+	/usr/local/sbin/acme.sh --set-default-ca --server letsencrypt
+	/usr/local/sbin/acme.sh --issue -d "$DOMAIN" --server letsencrypt \
+	 --home /mnt/acme --standalone --listen-v4 --httpport 80 --log /mnt/acme/acme.sh.log || true
+	if [ ! -f /mnt/acme/"$DOMAIN"_ecc/"$DOMAIN".cer ]; then
+		echo "Trying to register cert again, sleeping 30"
+		sleep 30
+		/usr/local/sbin/acme.sh --issue -d "$DOMAIN" --server letsencrypt \
+		 --home /mnt/acme --standalone --listen-v4 --httpport 80 --log /mnt/acme/acme.sh.log || true
+		if [ ! -f /mnt/acme/"$DOMAIN"_ecc/"$DOMAIN".cer ]; then
+			echo "missing $DOMAIN.cer, certificate not registered"
+			exit 1
+		fi
+	fi
+	# try continue, with a cert hopefully
+	cd /mnt/acme/"$DOMAIN"_ecc/ || true
+	cp -Rf /mnt/acme/"$DOMAIN"_ecc/ /usr/local/etc/ssl/
+else
+	echo "/mnt/acme/$DOMAIN _ecc exists, not creating certificates"
+	# try continue, with a cert hopefully
+	cd /mnt/acme/"$DOMAIN"_ecc/ || true
+	cp -Rf /mnt/acme/"$DOMAIN"_ecc/ /usr/local/etc/ssl/
+fi

--- a/netbox/netbox.d/local/share/cook/bin/configure-gunicorn.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-gunicorn.sh
@@ -16,10 +16,10 @@ export PATH=/usr/local/bin:$PATH
 # TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
 
 # enable gunicorn
-service gunicorn enable
+# service gunicorn enable
 
 # start gunicorn
-service gunicorn start
+# service gunicorn start
 
 
-
+# not in use

--- a/netbox/netbox.d/local/share/cook/bin/configure-netbox.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-netbox.sh
@@ -13,7 +13,10 @@ set -o pipefail
 export PATH=/usr/local/bin:$PATH
 
 # ensure necessary directories are present
-mkdir -p /mnt/netboxdata
+mkdir -p /mnt/netboxdata/media/devicetype-images
+mkdir -p /mnt/netboxdata/media/image-attachments
+chown www:www /mnt/netboxdata/media/devicetype-images
+chown www:www /mnt/netboxdata/media/image-attachments
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/netbox/netbox.d/local/share/cook/bin/configure-nginx.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-nginx.sh
@@ -15,6 +15,9 @@ export PATH=/usr/local/bin:$PATH
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
 
+# ensure this exists, won't if private cert option used
+mkdir -p /usr/local/www/acmetmp/
+
 # shellcheck disable=SC3003,SC2039
 # safe(r) separator for sed
 sep=$'\001'
@@ -22,6 +25,7 @@ sep=$'\001'
 # copy in custom nginx and set IP to ip address of pot image
 < "$TEMPLATEPATH/nginx.conf.in" \
   sed "s${sep}%%ip%%${sep}$IP${sep}g" \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
   > /usr/local/etc/nginx/nginx.conf
 
 # enable nginx

--- a/netbox/netbox.d/local/share/cook/bin/configure-ssl.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-ssl.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+if [ -e /root/.env.cook ]; then
+    . /root/.env.cook
+fi
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+# shellcheck disable=SC2086
+export PATH=/usr/local/bin:$PATH
+
+# shellcheck disable=SC2269
+DOMAIN="$DOMAIN"
+# shellcheck disable=SC2269
+IP="$IP"
+
+# create directory for local certificates
+mkdir -p /usr/local/etc/ssl/
+
+# better approach provided openssl >= 1.1.1
+# fullchain.cer is just the certificate, not a CA and intermediate too
+/usr/bin/openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:secp384r1 -days 3650 \
+  -nodes -keyout /usr/local/etc/ssl/"$DOMAIN".key -out /usr/local/etc/ssl/fullchain.cer -subj "/CN=$DOMAIN" \
+  -addext "subjectAltName=DNS:$DOMAIN,DNS:*.$DOMAIN,IP:$IP"
+
+# set permissions
+chmod 644 /usr/local/etc/ssl/fullchain.cer

--- a/netbox/netbox.d/local/share/cook/templates/configuration.py.in
+++ b/netbox/netbox.d/local/share/cook/templates/configuration.py.in
@@ -168,7 +168,9 @@ LOGOUT_REDIRECT_URL = 'home'
 
 # The file path where uploaded media such as image attachments are stored. A trailing slash is not needed. Note that
 # the default value of this setting is derived from the installed location.
-# MEDIA_ROOT = '/opt/netbox/netbox/media'
+#
+# pot image, set for mount in location to save files on new image
+MEDIA_ROOT = '/mnt/netboxdata/media'
 
 # Expose Prometheus monitoring metrics at the HTTP endpoint '/metrics'
 METRICS_ENABLED = True

--- a/netbox/netbox.d/local/share/cook/templates/nginx.conf.in
+++ b/netbox/netbox.d/local/share/cook/templates/nginx.conf.in
@@ -17,8 +17,34 @@ http {
 	fastcgi_send_timeout 600s;
 	fastcgi_read_timeout 600s;
 	server {
-		listen %%ip%%:80 default_server;
-		server_name netbox;
+		listen 80 default_server;
+		server_name _;
+		return 301 https://$host$request_uri;
+		location ~ ^/\.well-known/acme-challenge/([-_a-zA-Z0-9]+)$ {
+			alias /usr/local/www/acmetmp/;
+			allow all;
+			default_type "text/plain";
+		}
+	}
+	
+	server {
+		listen %%ip%%:443 ssl;
+		server_name %%domain%%;
+		http2 on;
+		ssl_certificate      /usr/local/etc/ssl/fullchain.cer;
+		ssl_certificate_key  /usr/local/etc/ssl/%%domain%%.key;
+		ssl_protocols TLSv1.3 TLSv1.2;
+		# https://ssl-config.mozilla.org/#server=nginx&config=intermediate
+		#ssl_ciphers  HIGH:!aNULL:!MD5;
+		ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+		ssl_session_cache    shared:SSL:10m;
+		ssl_session_timeout  5m;
+		ssl_session_tickets off;
+		ssl_prefer_server_ciphers  off;
+		ssl_early_data on;
+		add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+		add_header X-Frame-Options "DENY";
+		
 		client_max_body_size 512M;
 		client_body_timeout 600s;
 		fastcgi_buffers 64 4K;

--- a/netbox/netbox.d/local/share/cook/templates/update-certs.sh.in
+++ b/netbox/netbox.d/local/share/cook/templates/update-certs.sh.in
@@ -1,0 +1,22 @@
+#!/usr/local/bin/bash
+
+#mydomain="%%domain%%"
+registermail="%%email%%"
+
+if [ -d /mnt/acme/%%domain%%_ecc ]; then
+	service nginx stop
+	if [ -d /mnt/acme/%%domain%%_ecc.old ]; then
+		rm -rf /mnt/acme/%%domain%%_ecc.old
+	fi
+	mv -f /mnt/acme/%%domain%%_ecc /mnt/acme/%%domain%%_ecc.old
+	/usr/local/sbin/acme.sh --register-account -m "$registermail" --home /mnt/acme --server letsencrypt
+	/usr/local/sbin/acme.sh --set-default-ca --server letsencrypt
+	/usr/local/sbin/acme.sh --issue -d %%domain%% --home /mnt/acme --standalone --server letsencrypt --listen-v4 --httpport 80 --log /mnt/acme/acme.sh.log
+	cd /mnt/acme/%%domain%%_ecc/ || exit 1
+	cp -Rf /mnt/acme/%%domain%%_ecc/ /usr/local/etc/ssl/
+	service nginx restart
+	exit 0
+else
+	echo "There is no /mnt/acme/%%domain%%_ecc directory"
+	exit 1
+fi

--- a/netbox/netbox.ini
+++ b/netbox/netbox.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="netbox"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.0.9"
+version="0.0.10"
 origin="freebsd"
 runs_in_nomad="false"

--- a/netbox/netbox.sh
+++ b/netbox/netbox.sh
@@ -116,6 +116,9 @@ pkg install -y nano
 step "Install package bash"
 pkg install -y bash
 
+step "Install package acme.sh"
+pkg install -y acme.sh
+
 step "Install package git"
 pkg install -y git
 


### PR DESCRIPTION
Switch to using nginx with SSL, either via self-signed certificate, or acme.sh registration. Add renew script.

Set media location in mount in storage

Clean up CHECKLIST