### PR TITLE
Netbox: version bump for rebuild

### DIFF
--- a/netbox/CHANGELOG.md
+++ b/netbox/CHANGELOG.md
@@ -22,3 +22,5 @@
 * Set media location in mount in storage
 * Clean up CHECKLIST
 * Fix configure-nginx.sh config missing "|"
+* Fix missing logo on login page with clear alias to docs directory
+* Fix missing rack images by removing 'add_header X-Frame-Options "DENY"'

--- a/netbox/README.md
+++ b/netbox/README.md
@@ -123,3 +123,8 @@ The REMOTELOG parameter is the IP address of a destination ```syslog-ng``` serve
 
 TBA, Netbox is a "source of truth" for your network, with lots of configurable information, and IPAM for managing IP address allocations.
 
+Login with your configured superuser credentials and provision a site, add a rack, add manufacturers, device types, then add devices in the rack.
+
+Make sure you have pictures of the front and back of every server and network device to upload for the device entries.
+
+Add additional users to assist with the task of documenting your infrastructure. 

--- a/netbox/netbox.d/local/share/cook/templates/nginx.conf.in
+++ b/netbox/netbox.d/local/share/cook/templates/nginx.conf.in
@@ -43,13 +43,23 @@ http {
 		ssl_prefer_server_ciphers  off;
 		ssl_early_data on;
 		add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
-		add_header X-Frame-Options "DENY";
-		
+		# rack images break with this set, see
+		# https://github.com/netbox-community/netbox/discussions/10815
+		#add_header X-Frame-Options "DENY";
+		#
+
 		client_max_body_size 512M;
 		client_body_timeout 600s;
 		fastcgi_buffers 64 4K;
 		fastcgi_buffer_size 64k;
 		fastcgi_busy_buffers_size 64k;
+
+		location /static/netbox_logo.svg {
+			# This is also present in root of static/ but doesn't show up
+			# on login page. Setting specifically seems to work and can
+			# be adapted to a custom image too
+			alias /usr/local/share/netbox/static/docs/netbox_logo.svg;
+		}
 
 		location /static/ {
 			# from example but directory doesn't exist

--- a/netbox/netbox.ini
+++ b/netbox/netbox.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="netbox"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.0.11"
+version="0.0.12"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
Fix missing logo on login page with clear alias to docs directory

Fix missing rack images by removing 'add_header X-Frame-Options "DENY"'