### PR TITLE
Netbox: version bump for rebuild

### DIFF
--- a/netbox/CHANGELOG.md
+++ b/netbox/CHANGELOG.md
@@ -25,3 +25,4 @@
 * Fix missing logo on login page with clear alias to docs directory
 * Fix missing rack images by removing 'add_header X-Frame-Options "DENY"'
 * Add plugins netbox-secrets via pkg, and netbox-inventory, netbox-bgp, netbox-topology-views pip
+* Set versions on pip python installs

--- a/netbox/CHECKLIST.md
+++ b/netbox/CHECKLIST.md
@@ -27,5 +27,12 @@ Changes in python version need updating of package name, or `/usr/local/bin/pyth
 * `netbox.d/local/share/cook/bin/check-upgrade.sh`
 * `netbox.d/local/share/cook/templates/850.netbox-housekeeping.in`
 
+## Changes in netbox version and python pip installs
+Netbox is currently version 4.0.11. 
+When netbox is version 4.1.0 in packages, then update `netbox.sh` to correct version after checking compatibility chart at each link
+* `netbox-inventory==2.0.2` see Compatibility at https://github.com/ArnesSI/netbox-inventory
+* `netbox-bgp==0.13.3` see Compatibility at https://github.com/netbox-community/netbox-bgp
+* `netbox-topology-views==4.0.1` see Versions at https://github.com/netbox-community/netbox-topology-views
+
 ## Shellcheck
 Was `shellcheck` run on all applicable shell files?

--- a/netbox/netbox.ini
+++ b/netbox/netbox.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="netbox"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.0.13"
+version="0.0.14"
 origin="freebsd"
 runs_in_nomad="false"

--- a/netbox/netbox.sh
+++ b/netbox/netbox.sh
@@ -167,15 +167,17 @@ pkg clean -ay
 
 # netbox is running as root, the steps below are not ideal
 # might need to run as a netbox user, run netbox the same
+# set versions back a couple of releases from latest because error
+# Plugin netbox_inventory requires NetBox minimum version 4.1.0 (current: 4.0.11).
 
 step "Install python pip package netbox-inventory"
-/usr/local/bin/pip install --user netbox-inventory --root-user-action=ignore
+/usr/local/bin/pip install --user netbox-inventory==2.0.2 --root-user-action=ignore
 
 step "Install python pip package netbox-bgp"
-/usr/local/bin/pip install --user netbox-bgp --root-user-action=ignore
+/usr/local/bin/pip install --user netbox-bgp==0.13.3 --root-user-action=ignore
 
 step "Install python pip package netbox-topology-views"
-/usr/local/bin/pip install --user netbox-topology-views --root-user-action=ignore
+/usr/local/bin/pip install --user netbox-topology-views==4.0.1 --root-user-action=ignore
 
 #
 # Now generate the run command script "cook"


### PR DESCRIPTION
Set versions on pip python installs

Error: Plugin plugin-name requires NetBox minimum version 4.1.0 (current: 4.0.11).