### PR TITLE
Mass update for 2025Q1

### DIFF
--- a/adminer/CHANGELOG.md
+++ b/adminer/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.11
+
+* Version bump for new base image
+* Update to php83
+
+---
+
 0.10
 
 * Version bump for new base image 14.2

--- a/adminer/CHECKLIST.md
+++ b/adminer/CHECKLIST.md
@@ -13,14 +13,18 @@ In `adminer/adminer.d/local/share/cook/bin/configure-adminer.sh` update:
 
 In `adminer/adminer.sh` update:
 ```sh
-pkg install -y php82
-pkg install -y php82-mbstring
-pkg install -y php82-zlib
-pkg install -y php82-curl
-pkg install -y php82-gd
-pkg install -y php82-extensions
-pkg install -y php82-mysqli
-pkg install -y php82-odbc
-pkg install -y php82-pgsql
-pkg install -y php82-pdo_sqlite
+pkg install -y php83
+pkg install -y php83-mbstring
+pkg install -y php83-zlib
+pkg install -y php83-curl
+pkg install -y php83-gd
+pkg install -y php83-extensions
+pkg install -y php83-mysqli
+pkg install -y php83-odbc
+pkg install -y php83-pgsql
+pkg install -y php83-pdo_sqlite
 ```
+
+Also update the PHP socket in
+* `adminer.d/local/share/cook/templates/nginx.conf.in`
+* `adminer.d/local/share/cook/templates/www.conf.in`

--- a/adminer/README.md
+++ b/adminer/README.md
@@ -29,13 +29,13 @@ To deploy `adminer-editor` instead of the full **Adminer** set environment varia
 * Clone the local jail
 * Adjust to your environment:
   ```sh
-  sudo pot set-env -p <jailname> \
+   sudo pot set-env -p <jailname> \
    -E DATACENTER=<datacenter name> \
    -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-   -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+   -E GOSSIPKEY="<32 byte Base64 key from consul keygen>" \
    -E NODENAME=<name of node> \
    -E IP=<IP address> \
-   -E SERVERNAME=<hostname/IP> \
+   -E SERVERNAME=<hostname or IP> \
    [ -E REMOTELOG=<IP of syslog-ng server> ]
    [ -E EDITOR=<true/false> ]
    [ -E DBSERVER=<IP/hostname of the database> ]

--- a/adminer/adminer.d/local/share/cook/templates/nginx.conf.in
+++ b/adminer/adminer.d/local/share/cook/templates/nginx.conf.in
@@ -49,7 +49,7 @@ http {
             # Mitigate https://httpoxy.org/ vulnerabilities
             fastcgi_param HTTP_PROXY "";
 
-            fastcgi_pass unix:/var/run/php82-fpm.sock;
+            fastcgi_pass unix:/var/run/php83-fpm.sock;
             fastcgi_read_timeout 300;
             fastcgi_index index.php;
 

--- a/adminer/adminer.d/local/share/cook/templates/www.conf.in
+++ b/adminer/adminer.d/local/share/cook/templates/www.conf.in
@@ -1,7 +1,7 @@
 [www]
 user = www
 group = www
-listen = /var/run/php82-fpm.sock
+listen = /var/run/php83-fpm.sock
 listen.owner = www
 listen.group = www
 listen.mode = 0660

--- a/adminer/adminer.ini
+++ b/adminer/adminer.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="adminer"
 author="Deividas Gedgaudas"
-version="0.10.1"
+version="0.11.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/adminer/adminer.sh
+++ b/adminer/adminer.sh
@@ -108,34 +108,34 @@ step "Install nginx"
 pkg install -y nginx
 
 step "Install PHP"
-pkg install -y php82
+pkg install -y php83
 
 step "Install PHP mbstring"
-pkg install -y php82-mbstring
+pkg install -y php83-mbstring
 
 step "Install PHP zlib"
-pkg install -y php82-zlib
+pkg install -y php83-zlib
 
 step "Install PHP curl"
-pkg install -y php82-curl
+pkg install -y php83-curl
 
 step "Install PHP gd"
-pkg install -y php82-gd
+pkg install -y php83-gd
 
 step "Install PHP extensions"
-pkg install -y php82-extensions
+pkg install -y php83-extensions
 
 step "Install PHP mysqli driver"
-pkg install -y php82-mysqli
+pkg install -y php83-mysqli
 
 step "Install PHP odbc driver"
-pkg install -y php82-odbc
+pkg install -y php83-odbc
 
 step "Install PHP pgsql driver"
-pkg install -y php82-pgsql
+pkg install -y php83-pgsql
 
 step "Install PHP pdo_sqlite driver"
-pkg install -y php82-pdo_sqlite
+pkg install -y php83-pdo_sqlite
 
 step "Clean package installation"
 pkg clean -ay

--- a/backuppc-nomad/CHANGELOG.md
+++ b/backuppc-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.20
+
+* Version bump for new base image
+
+---
+
 1.19
 
 * Version bump for new base image 14.2

--- a/backuppc-nomad/README.md
+++ b/backuppc-nomad/README.md
@@ -64,7 +64,7 @@ job "backuppc" {
       config {
         image = "https://potluck.honeyguide.net/backuppc-nomad"
         pot = "backuppc-nomad-amd64-14_2"
-        tag = "1.19.1"
+        tag = "1.20.1"
         command = "/usr/local/bin/cook"
         args = ["-p","myadminpassword"]
         mount = [

--- a/backuppc-nomad/backuppc-nomad.ini
+++ b/backuppc-nomad/backuppc-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="backuppc-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.19.1"
+version="1.20.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/beast-of-argh/CHANGELOG.md
+++ b/beast-of-argh/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.24
+
+* Version bump for new base image
+
+---
+
 0.23
 
 * Version bump for new base image 14.2

--- a/beast-of-argh/README.md
+++ b/beast-of-argh/README.md
@@ -30,7 +30,7 @@ The flavour includes a local ```consul``` agent instance to be available that it
     -E NODENAME=<nodename> \
     -E IP=<IP address of this system> \
     -E CONSULSERVERS=<consul IP address(es) in comma-deliminated format> \
-    -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+    -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
     -E GRAFANAUSER=<grafana username> \
     -E GRAFANAPASSWORD=<grafana password> \
     -E SCRAPECONSUL=<consul IP address(es) in comma-deliminated format> \

--- a/beast-of-argh/beast-of-argh.ini
+++ b/beast-of-argh/beast-of-argh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="beast-of-argh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.23.1"
+version="0.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/caddy-s3-nomad/CHANGELOG.md
+++ b/caddy-s3-nomad/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.17
+
+* Version bump for new base image
+* Update to 2025Q1 for pkg sources
+
+---
+
 0.16
 
 * Version bump for new base image 14.2

--- a/caddy-s3-nomad/CHECKLIST.md
+++ b/caddy-s3-nomad/CHECKLIST.md
@@ -20,13 +20,13 @@ To force a rebuild of the pot image for the potluck site, increment Z of version
 * `caddy-s3-nomad.ini`
 
 ## Go Version
-When `go` version changes updated the package install line and git sparse checkout lines in:
+If set to a version, then when `go` version changes updated the package install line and git sparse checkout lines in:
 * `caddy-s3-nomad.sh`
 
 ## Quarterly Package Updates
 Every new quarterly pkg release, update this line to next applicable quarter
 ```
-git pull --depth=1 origin 2024Q4
+git pull --depth=1 origin 2025Q1
 ```
 in:
 * `caddy-s3-nomad.sh`

--- a/caddy-s3-nomad/README.md
+++ b/caddy-s3-nomad/README.md
@@ -98,7 +98,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/caddy-s3-nomad"
         pot = "caddy-s3-nomad-amd64-14_2"
-        tag = "0.16.1"
+        tag = "0.17.1"
         command = "/usr/local/bin/cook"
         args = ["-h","s3.my.host","-b","bucketname","-d","domainname","-e","email@add.com","-s","yes"]
 		mount = [

--- a/caddy-s3-nomad/caddy-s3-nomad.ini
+++ b/caddy-s3-nomad/caddy-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="caddy-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.16.1"
+version="0.17.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/caddy-s3-nomad/caddy-s3-nomad.sh
+++ b/caddy-s3-nomad/caddy-s3-nomad.sh
@@ -181,7 +181,8 @@ git sparse-checkout set GIDs UIDs \
 step "Pull files"
 #git pull --depth=1 origin 2023Q3
 #git pull --depth=1 origin 2024Q2
-git pull --depth=1 origin 2024Q4
+#git pull --depth=1 origin 2024Q4
+git pull --depth=1 origin 2025Q1
 
 # go straight to building caddy-custom
 #step "Build caddy"

--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.23
+
+* Version bump for new base image
+
+---
+
 2.22
 
 * Version bump for new base image 14.2

--- a/consul/consul.ini
+++ b/consul/consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.22.1"
+version="2.23.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/dmarc-report/CHANGELOG.md
+++ b/dmarc-report/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.19
+
+* Version bump for new base image
+
+---
+
 0.18
 
 * Version bump for new base image 14.2

--- a/dmarc-report/README.md
+++ b/dmarc-report/README.md
@@ -35,7 +35,7 @@ There is no progress indicator when complete. When your dmarc folder empties, th
     -E NODENAME=<nodename> \
     -E IP=<IP address of this system> \
     -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-    -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+    -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
     -E IMAPSERVER=<mail host> \
     -E IMAPUSER=<imap username> \
     -E IMAPPASS=<imap password> \

--- a/dmarc-report/dmarc-report.ini
+++ b/dmarc-report/dmarc-report.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="dmarc-report"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.18.1"
+version="0.19.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/freebsd-potluck/README.md
+++ b/freebsd-potluck/README.md
@@ -7,7 +7,7 @@ tags: ["base image", "layers", "testing"]
 
 # Overview
 
-This flavour is a bare base pot image. Just FreeBSD-14.1.
+This flavour is a bare base pot image. Just FreeBSD-14.2.
 
 # Installation
 

--- a/git-nomad/CHANGELOG.md
+++ b/git-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.22
+
+* Version bump for new base image
+
+---
+
 1.21
 
 * Version bump for new base image 14.2

--- a/git-nomad/README.md
+++ b/git-nomad/README.md
@@ -53,7 +53,7 @@ job "examplegit" {
       config {
         image = "https://potluck.honeyguide.net/git-nomad"
         pot = "git-nomad-amd64-14_2"
-        tag = "1.21.1"
+        tag = "1.22.1"
         command = "/usr/local/bin/cook"
         args = ["-n","gitnomad"]
 

--- a/git-nomad/git-nomad.ini
+++ b/git-nomad/git-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="git-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.21.1"
+version="1.22.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/haproxy-minio/CHANGELOG.md
+++ b/haproxy-minio/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.11
+
+* Version bump for new base image
+
+---
+
 0.10
 
 * Version bump for new base image 14.2

--- a/haproxy-minio/haproxy-minio.ini
+++ b/haproxy-minio/haproxy-minio.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-minio"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.10.1"
+version="0.11.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy-sql/CHANGELOG.md
+++ b/haproxy-sql/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.16
+
+* Version bump for new base image
+
+---
+
 0.15
 
 * Version bump for new base image 14.2

--- a/haproxy-sql/README.md
+++ b/haproxy-sql/README.md
@@ -38,7 +38,7 @@ The `mariadb` pot images must already be started with the LOADBALANCER parameter
   sudo pot set-env -p <jailname> \
    -E DATACENTER=<datacenter name> \
    -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-   -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+   -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
    -E NODENAME=<name of node> \
    -E IP=<IP address> \
    -E SERVERONE=<IP address first mariadb host> \

--- a/haproxy-sql/haproxy-sql.ini
+++ b/haproxy-sql/haproxy-sql.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-sql"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.15.1"
+version="0.16.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/hugo-nginx-alt/CHANGELOG.md
+++ b/hugo-nginx-alt/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.11
+
+* Version bump for new base image
+
+---
+
 0.10
 
 * Version bump for new base image 14.2

--- a/hugo-nginx-alt/hugo-nginx-alt.ini
+++ b/hugo-nginx-alt/hugo-nginx-alt.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx-alt"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.10.1"
+version="0.11.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/hugo-nginx/CHANGELOG.md
+++ b/hugo-nginx/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.22
+
+* Version bump for new base image
+
+---
+
 0.21
 
 * Version bump for new base image 14.2

--- a/hugo-nginx/hugo-nginx.ini
+++ b/hugo-nginx/hugo-nginx.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.21.1"
+version="0.22.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/jenkins/CHANGELOG.md
+++ b/jenkins/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.22
+
+* Version bump for new base image
+
+---
+
 0.21
 
 * Version bump for new base image 14.2

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -34,7 +34,7 @@ You can adjust this flavour and rebuild your own pot image if you have other req
     -E NODENAME=<nodename> \
     -E IP=<IP address of this system> \
     -E CONSULSERVERS=<comma-deliminated list of consul servers> \
-    -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+    -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
     -E RUNTYPE=<nostore|setupstore|activestore> \
     -E BUILDHOST=<IP of potbuilder VM> \
     [ -E IMPORTKEYS=<1|0 default> ] \

--- a/jenkins/jenkins.ini
+++ b/jenkins/jenkins.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="jenkins"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.21.1"
+version="0.22.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mailhub-potluck/CHANGELOG.md
+++ b/mailhub-potluck/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.20
+
+* Version bump for new base image
+* Update to 2025Q1 for pkg sources
+
+---
+
 0.19
 
 * Version bump for new base image 14.2

--- a/mailhub-potluck/CHECKLIST.md
+++ b/mailhub-potluck/CHECKLIST.md
@@ -21,7 +21,7 @@ To force a rebuild of the pot image for the potluck site, increment Z of version
 ## Quarterly Package Updates
 Every new quarterly pkg release, update this line to next applicable quarter
 ```
-git pull --depth=1 origin 2024Q4
+git pull --depth=1 origin 2025Q1
 ```
 in this file:
 * `mailhub-potluck.sh`

--- a/mailhub-potluck/mailhub-potluck.ini
+++ b/mailhub-potluck/mailhub-potluck.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mailhub-potluck"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.19.1"
+version="0.20.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mailhub-potluck/mailhub-potluck.sh
+++ b/mailhub-potluck/mailhub-potluck.sh
@@ -186,8 +186,8 @@ pkg install -y pkgconf
 step "Install package zstd"
 pkg install -y zstd
 
-step "Install package python39"
-pkg install -y python39
+step "Install package python3"
+pkg install -y python3
 
 step "Install package acme.sh"
 pkg install -y acme.sh
@@ -218,8 +218,8 @@ pkg install -y node_exporter
 step "Install package git-lite"
 pkg install -y git-lite
 
-step "Install package go"
-pkg install -y go
+step "Install package lang/go"
+pkg install -y lang/go
 
 step "Add openssl and ldap settings to make.conf"
 echo "BATCH=yes" > /etc/make.conf
@@ -302,7 +302,8 @@ step "Pull files"
 #git pull --depth=1 origin 2024Q1
 #git pull --depth=1 origin 2024Q2
 #git pull --depth=1 origin 2024Q3
-git pull --depth=1 origin 2024Q4
+#git pull --depth=1 origin 2024Q4
+git pull --depth=1 origin 2025Q1
 
 #step "Port build openssl, remove existing, replace with this port"
 ##required for latest / main branch

--- a/mariadb-galera/CHANGELOG.md
+++ b/mariadb-galera/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.15
+
+* Version bump for new base image
+
+---
+
 0.14
 
 * Version bump for new base image 14.2

--- a/mariadb-galera/mariadb-galera.ini
+++ b/mariadb-galera/mariadb-galera.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb-galera"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.14.1"
+version="0.15.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,3 +1,9 @@
+4.12
+
+* Version bump for new base image
+
+---
+
 4.11
 
 * Version bump for new base image 14.2

--- a/mariadb/mariadb.ini
+++ b/mariadb/mariadb.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="4.11.1"
+version="4.12.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mastodon-s3/CHANGELOG.md
+++ b/mastodon-s3/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.18
+
+* Version bump for new image
+
+---
+
 0.17
 
 * Version bump for 14.2

--- a/mastodon-s3/mastodon-s3.ini
+++ b/mastodon-s3/mastodon-s3.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mastodon-s3"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.17.1"
+version="0.18.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/matrix-synapse/CHANGELOG.md
+++ b/matrix-synapse/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.12
+
+* Version bump for new base image
+
+---
+
 2.11
 
 * Version bump for new base image 14.2

--- a/matrix-synapse/README.md
+++ b/matrix-synapse/README.md
@@ -40,7 +40,7 @@ This is a quirk of using `.well-known/matrix/server` with the server's details.
   sudo pot set-env -p <jailname> \
    -E DATACENTER=<datacenter name> \
    -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-   -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+   -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
    -E NODENAME=<name of node> \
    -E IP=<IP address> \
    -E DOMAIN=<domain name> \

--- a/matrix-synapse/matrix-synapse.ini
+++ b/matrix-synapse/matrix-synapse.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="matrix-synapse"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.11.1"
+version="2.12.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/netbox/CHANGELOG.md
+++ b/netbox/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.1
+
+* Version bump for new base image
+* Update for Netbox version 4.1.10 
+
 ---
 
 0.0

--- a/netbox/CHECKLIST.md
+++ b/netbox/CHECKLIST.md
@@ -28,11 +28,12 @@ Changes in python version need updating of package name, or `/usr/local/bin/pyth
 * `netbox.d/local/share/cook/templates/850.netbox-housekeeping.in`
 
 ## Changes in netbox version and python pip installs
-Netbox is currently version 4.0.11. 
-When netbox is version 4.1.0 in packages, then update `netbox.sh` to correct version after checking compatibility chart at each link
-* `netbox-inventory==2.0.2` see Compatibility at https://github.com/ArnesSI/netbox-inventory
-* `netbox-bgp==0.13.3` see Compatibility at https://github.com/netbox-community/netbox-bgp
-* `netbox-topology-views==4.0.1` see Versions at https://github.com/netbox-community/netbox-topology-views
+Netbox is currently version 4.1.10.
+
+When netbox version changes in packages, then update `netbox.sh` to correct version after checking compatibility chart at each link
+* `netbox-inventory==2.2.1` see Compatibility at https://github.com/ArnesSI/netbox-inventory
+* `netbox-bgp==0.14.0` see Compatibility at https://github.com/netbox-community/netbox-bgp
+* `netbox-topology-views==4.1.0` see Versions at https://github.com/netbox-community/netbox-topology-views
 
 ## Shellcheck
 Was `shellcheck` run on all applicable shell files?

--- a/netbox/netbox.ini
+++ b/netbox/netbox.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="netbox"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.0.15"
+version="0.1.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/netbox/netbox.sh
+++ b/netbox/netbox.sh
@@ -149,8 +149,8 @@ pkg install -y syslog-ng
 step "Install package redis"
 pkg install -y redis
 
-step "Install package postgresql15-client"
-pkg install -y postgresql15-client
+step "Install package postgresql16-client"
+pkg install -y postgresql16-client
 
 step "Install package netbox"
 pkg install -y netbox
@@ -173,13 +173,13 @@ pkg clean -ay
 #  Plugin netbox_inventory requires NetBox minimum version 4.1.0 (current: 4.0.11).
 
 step "Install python pip package netbox-inventory"
-/usr/local/bin/pip install netbox-inventory==2.0.2 --root-user-action=ignore
+/usr/local/bin/pip install netbox-inventory==2.2.1 --root-user-action=ignore
 
 step "Install python pip package netbox-bgp"
-/usr/local/bin/pip install netbox-bgp==0.13.3 --root-user-action=ignore
+/usr/local/bin/pip install netbox-bgp==0.14.0 --root-user-action=ignore
 
 step "Install python pip package netbox-topology-views"
-/usr/local/bin/pip install netbox-topology-views==4.0.1 --root-user-action=ignore
+/usr/local/bin/pip install netbox-topology-views==4.1.0 --root-user-action=ignore
 
 #
 # Now generate the run command script "cook"

--- a/nextcloud-nginx-nomad/CHANGELOG.md
+++ b/nextcloud-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.113
+
+* Version bump for new quarterlies
+
+---
+
 0.112
 
 * Include proxy.config.php option for setting trusted proxies

--- a/nextcloud-nginx-nomad/README.md
+++ b/nextcloud-nginx-nomad/README.md
@@ -246,7 +246,7 @@ job "nextcloud" {
       config {
         image = "https://potluck.honeyguide.net/nextcloud-nginx-nomad"
         pot = "nextcloud-nginx-nomad-amd64-14_2"
-        tag = "0.112"
+        tag = "0.113"
         command = "/usr/local/bin/cook"
         args = ["-d","/mnt/filestore","-s","host:ip"]
         copy = [

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.112"
+version="0.113"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nextcloud-spreed-signalling/CHANGELOG.md
+++ b/nextcloud-spreed-signalling/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.5
+
+* Version bump for new base image
+
+---
+
 0.4
 
 * Version bump for new base image 14.2

--- a/nextcloud-spreed-signalling/README.md
+++ b/nextcloud-spreed-signalling/README.md
@@ -36,7 +36,7 @@ You must run this instance from a top level domain such as `signal.yourdomain.co
   sudo pot set-env -p <jailname> \
    -E DATACENTER=<datacenter name> \
    -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-   -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+   -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
    -E NODENAME=<name of node> \
    -E IP=<IP address> \
    -E DOMAIN=<domain name> \

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-spreed-signalling"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.4.1"
+version="0.5.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-nomad-alt/CHANGELOG.md
+++ b/nginx-nomad-alt/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.21
+
+* Version bump for new base image
+* Switch to php83
+
+---
+
 0.20
 
 * Version bump for new base image 14.2

--- a/nginx-nomad-alt/CHECKLIST.md
+++ b/nginx-nomad-alt/CHECKLIST.md
@@ -19,5 +19,10 @@ Changes to major or minor versions need to be logged in:
 To force a rebuild of the pot image for the potluck site, increment Z of version="x.y.Z" in:
 * `nginx-nomad-alt.ini`
 
+## PHP version changes
+On PHP version changes, update the socket link `/var/run/php83-fpm.sock` to the new PHP version in files
+* `nginx-nomad-alt.d/local/share/cook/templates/nginx.conf`
+* `nginx-nomad-alt.d/local/share/cook/templates/www.conf.in`
+
 ## Shellcheck
 Was `shellcheck` run on all applicable shell files?

--- a/nginx-nomad-alt/README.md
+++ b/nginx-nomad-alt/README.md
@@ -63,7 +63,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-nomad-alt"
         pot = "nginx-nomad-alt-amd64-14_2"
-        tag = "0.20.1"
+        tag = "0.21.1"
         command = "/usr/local/bin/cook"
         args = ["-s","servername"]
         mount = [

--- a/nginx-nomad-alt/nginx-nomad-alt.d/local/share/cook/templates/nginx.conf.in
+++ b/nginx-nomad-alt/nginx-nomad-alt.d/local/share/cook/templates/nginx.conf.in
@@ -49,7 +49,7 @@ http {
             # Mitigate https://httpoxy.org/ vulnerabilities
             fastcgi_param HTTP_PROXY "";
 
-            fastcgi_pass unix:/var/run/php82-fpm.sock;
+            fastcgi_pass unix:/var/run/php83-fpm.sock;
             fastcgi_read_timeout 300;
             fastcgi_index index.php;
 

--- a/nginx-nomad-alt/nginx-nomad-alt.d/local/share/cook/templates/www.conf.in
+++ b/nginx-nomad-alt/nginx-nomad-alt.d/local/share/cook/templates/www.conf.in
@@ -1,7 +1,7 @@
 [www]
 user = www
 group = www
-listen = /var/run/php82-fpm.sock
+listen = /var/run/php83-fpm.sock
 listen.owner = www
 listen.group = www
 listen.mode = 0660

--- a/nginx-nomad-alt/nginx-nomad-alt.ini
+++ b/nginx-nomad-alt/nginx-nomad-alt.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-nomad-alt"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.1"
+version="0.21.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-nomad-alt/nginx-nomad-alt.sh
+++ b/nginx-nomad-alt/nginx-nomad-alt.sh
@@ -121,23 +121,23 @@ pkg install -y sudo
 step "Install package nginx"
 pkg install -y nginx
 
-step "Install package php82"
-pkg install -y php82
+step "Install package php83"
+pkg install -y php83
 
-step "Install package php82-mbstring"
-pkg install -y php82-mbstring
+step "Install package php83-mbstring"
+pkg install -y php83-mbstring
 
-step "Install package php82-zlib"
-pkg install -y php82-zlib
+step "Install package php83-zlib"
+pkg install -y php83-zlib
 
-step "Install package php82-curl"
-pkg install -y php82-curl
+step "Install package php83-curl"
+pkg install -y php83-curl
 
-step "Install package php82-gd"
-pkg install -y php82-gd
+step "Install package php83-gd"
+pkg install -y php83-gd
 
-step "Install package php82-extensions"
-pkg install -y php82-extensions
+step "Install package php83-extensions"
+pkg install -y php83-extensions
 
 step "Clean package installation"
 pkg clean -ay

--- a/nginx-rsync-ssh/CHANGELOG.md
+++ b/nginx-rsync-ssh/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.23
+
+* Version bump for new base image
+
+---
+
 0.22
 
 * Version bump for new base image 14.2

--- a/nginx-rsync-ssh/README.md
+++ b/nginx-rsync-ssh/README.md
@@ -48,7 +48,7 @@ You can adjust this flavour and rebuild your own pot image if you have other req
    -E NODENAME=<nodename> \
    -E IP=<IP address of this system> \
    -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-   -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+   -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
    -E SETUPSCRIPT=<1 | 0 default> \
    -E IMPORTAUTHKEY=<1 | 0 default> \
    -E IMPORTSSH=<1 | 0 default> \

--- a/nginx-rsync-ssh/nginx-rsync-ssh.ini
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-rsync-ssh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.22.1"
+version="0.23.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-s3-nomad/CHANGELOG.md
+++ b/nginx-s3-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.23
+
+* Version bump for new base image
+
+---
+
 0.22
 
 * Version bump for new base image 14.2

--- a/nginx-s3-nomad/README.md
+++ b/nginx-s3-nomad/README.md
@@ -96,7 +96,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
         pot = "nginx-s3-nomad-amd64-14_2"
-        tag = "0.22.1"
+        tag = "0.23.1"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-x","bucketname","-s","yes"]
         port_map = {
@@ -150,7 +150,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
         pot = "nginx-s3-nomad-amd64-14_2"
-        tag = "0.22.1"
+        tag = "0.23.1"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-c","10.0.0.4","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-nomad/nginx-s3-nomad.ini
+++ b/nginx-s3-nomad/nginx-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.22.1"
+version="0.23.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-s3-ssl-nomad/CHANGELOG.md
+++ b/nginx-s3-ssl-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.12
+
+* Version bump for new base image
+
+---
+
 0.11
 
 * Version bump for new base image 14.2

--- a/nginx-s3-ssl-nomad/README.md
+++ b/nginx-s3-ssl-nomad/README.md
@@ -98,7 +98,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.11.1"
+        tag = "0.12.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -152,7 +152,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.11.1"
+        tag = "0.12.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -206,7 +206,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.11.1"
+        tag = "0.12.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-g","10.0.0.4:9000","-h","10.0.0.5:9000","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.11.1"
+version="0.12.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-varnish-ssl-nomad/CHANGELOG.md
+++ b/nginx-varnish-ssl-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3
+
+* Version bump for new base image
+
+---
+
 0.2
 
 * Version bump for new base image 14.2

--- a/nginx-varnish-ssl-nomad/README.md
+++ b/nginx-varnish-ssl-nomad/README.md
@@ -69,7 +69,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-varnish-ssl-nomad"
         pot = "nginx-varnish-ssl-nomad-amd64-14_2"
-        tag = "0.2.1"
+        tag = "0.3.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-s","10.0.0.2:8080","-b","bucketname"]
         port_map = {

--- a/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
+++ b/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-varnish-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.2.1"
+version="0.3.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nomad-server/CHANGELOG.md
+++ b/nomad-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.24
+
+* Version bump for new base image
+
+---
+
 3.23
 
 * Version bump for new base image 14.2

--- a/nomad-server/nomad-server.ini
+++ b/nomad-server/nomad-server.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nomad-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="3.23.1"
+version="3.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/openldap/CHANGELOG.md
+++ b/openldap/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.25
+
+* Version bump for new base image
+
+---
+
 1.24
 
 * Version bump for new base image 14.2

--- a/openldap/CHECKLIST.md
+++ b/openldap/CHECKLIST.md
@@ -19,7 +19,7 @@ To force a rebuild of the pot image for the potluck site, increment Z of version
 * `openldap.ini`
 
 ## PHP version changes
-Update the pkg install commands in, current is php83
+Update the pkg install commands in, current is php82 because dependencies
 * `openldap.sh`
 
 Make sure to change the php socket filename in

--- a/openldap/CHECKLIST.md
+++ b/openldap/CHECKLIST.md
@@ -19,7 +19,7 @@ To force a rebuild of the pot image for the potluck site, increment Z of version
 * `openldap.ini`
 
 ## PHP version changes
-Update the pkg install commands in, current is php82
+Update the pkg install commands in, current is php83
 * `openldap.sh`
 
 Make sure to change the php socket filename in

--- a/openldap/openldap.ini
+++ b/openldap/openldap.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="openldap"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.24.1"
+version="1.25.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/openldap/openldap.sh
+++ b/openldap/openldap.sh
@@ -140,6 +140,7 @@ pkg install -y p5-Archive-Zip
 step "Install package apache24"
 pkg install -y apache24
 
+# no php83 yet as dependencies on php82 during install steps
 step "Install package php82"
 pkg install -y php82
 

--- a/opensearch/CHANGELOG.md
+++ b/opensearch/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.9
+
+* Version bump for new base image
+
+---
+
 0.8
 
 * Version bump for new base image 14.2

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -34,7 +34,7 @@ The flavour includes a local ```consul``` agent instance to be available that it
     -E NODENAME=<nodename> \
     -E IP=<IP address of this system> \
     -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-    -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+    -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
     [ -E PORT=<opensearch port, default 9200> ] \
     [ -E REMOTELOG=<IP address> ]
   ```

--- a/opensearch/opensearch.ini
+++ b/opensearch/opensearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="opensearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.8.1"
+version="0.9.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/postfix-backupmx-nomad/CHANGELOG.md
+++ b/postfix-backupmx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.20
+
+* Version bump for new base image
+
+---
+
 1.19
 
 * Version bump for new base image 14.2

--- a/postfix-backupmx-nomad/README.md
+++ b/postfix-backupmx-nomad/README.md
@@ -54,7 +54,7 @@ job "backupmx" {
       config {
         image = "https://potluck.honeyguide.net/postfix-backupmx-nomad"
         pot = "postfix-backupmx-nomad-amd64-14_2"
-        tag = "1.19.1"
+        tag = "1.20.1"
         command = "/usr/local/bin/cook"
         args = ["-n","10.10.10.10/32","-d","'example1.com, example2.com, example.de'","-b","'mx2.example1.com ESMTP \\$mail_name'","-h","mx2.example1.com"]
         mount = [
@@ -117,7 +117,7 @@ job "backupmx" {
        config {
         image = "https://potluck.honeyguide.net/postfix-backupmx-nomad"
         pot = "postfix-backupmx-nomad-amd64-14_2"
-        tag = "1.19.1"
+        tag = "1.20.1"
         command = "/usr/local/bin/cook"
         args = [""]
 

--- a/postfix-backupmx-nomad/postfix-backupmx-nomad.ini
+++ b/postfix-backupmx-nomad/postfix-backupmx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postfix-backupmx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.19.1"
+version="1.20.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/postgres-single/CHANGELOG.md
+++ b/postgres-single/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.14
+
+* Version bump for new base image
+
+---
+
 0.13
 
 * Version bump for new base image 14.2

--- a/postgres-single/README.md
+++ b/postgres-single/README.md
@@ -43,7 +43,7 @@ This jail must be run with a non-routable IP address, accessible only to the int
   sudo pot set-env -p <jailname> \
    -E DATACENTER=<datacenter name> \
    -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-   -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+   -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
    -E NODENAME=<name of node> \
    -E IP=<IP address> \
    -E IP4NETWORK=<10.0.0.1/24> \

--- a/postgres-single/postgres-single.ini
+++ b/postgres-single/postgres-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postgres-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.13.2"
+version="0.14.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/rbldnsd/CHANGELOG.md
+++ b/rbldnsd/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.22
+
+* Version bump for new base image
+* Update to php83
+
+---
+
 0.21
 
 * Version bump for new base image 14.2

--- a/rbldnsd/README.md
+++ b/rbldnsd/README.md
@@ -24,7 +24,7 @@ The flavour includes a local ```consul``` agent instance to be available that it
     -E NODENAME=<nodename> \
     -E IP=<IP address of this system> \
     -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-    -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+    -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
     -E DOMAIN=<your domain name> \
     -E SSLEMAIL="<email address for certificate rgistration>" \
     [ -E REMOTELOG=<IP address> ] \

--- a/rbldnsd/rbldnsd.ini
+++ b/rbldnsd/rbldnsd.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="rbldnsd"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.21.1"
+version="0.22.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/rbldnsd/rbldnsd.sh
+++ b/rbldnsd/rbldnsd.sh
@@ -131,20 +131,20 @@ pkg install -y rbldnsd
 step "Install package git-lite"
 pkg install -y git-lite
 
-step "Install package php82"
-pkg install -y php82
+step "Install package php83"
+pkg install -y php83
 
-step "Install package php82-mbstring"
-pkg install -y php82-mbstring
+step "Install package php83-mbstring"
+pkg install -y php83-mbstring
 
-step "Install package php82-zlib"
-pkg install -y php82-zlib
+step "Install package php83-zlib"
+pkg install -y php83-zlib
 
-step "Install package php82-curl"
-pkg install -y php82-curl
+step "Install package php83-curl"
+pkg install -y php83-curl
 
-step "Install package php82-gd"
-pkg install -y php82-gd
+step "Install package php83-gd"
+pkg install -y php83-gd
 
 step "Install package syslog-ng"
 pkg install -y syslog-ng

--- a/redis-single/CHANGELOG.md
+++ b/redis-single/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.14
+
+* Version bump for new base image
+
+---
+
 0.13
 
 * Version bump for new base image 14.2

--- a/redis-single/README.md
+++ b/redis-single/README.md
@@ -41,7 +41,7 @@ An optional password can provide an additional level of access control.
   sudo pot set-env -p <jailname> \
    -E DATACENTER=<datacenter name> \
    -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-   -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+   -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
    -E NODENAME=<name of node> \
    -E IP=<IP address> \
    [ -E AUTHPASS=<authorization password> ] \

--- a/redis-single/redis-single.ini
+++ b/redis-single/redis-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="redis-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.13.1"
+version="0.14.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/saltstack/CHANGELOG.md
+++ b/saltstack/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.22
+
+* Version bump for new base image
+
+---
+
 0.21
 
 * Version bump for new base image 14.2

--- a/saltstack/saltstack.ini
+++ b/saltstack/saltstack.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="saltstack"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.21.1"
+version="0.22.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traefik-consul/CHANGELOG.md
+++ b/traefik-consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.26
+
+* Version bump for new base image
+
+---
+
 1.25
 
 * Version bump for new base image 14.2

--- a/traefik-consul/README.md
+++ b/traefik-consul/README.md
@@ -24,7 +24,7 @@ This is a flavour containing the ```traefik``` reverse proxy and load balancer p
     -E NODENAME=<nodename> \
     -E IP=<IP address of this system> \
     -E CONSULSERVERS="<comma-deliminated list of consul IP addresses>" \
-    -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+    -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
     [ -E REMOTELOG=<IP address> ]
   ```
 * Start jail with ```pot start <jailname>```

--- a/traefik-consul/traefik-consul.ini
+++ b/traefik-consul/traefik-consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traefik-consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.25.1"
+version="1.26.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traumadrill/CHANGELOG.md
+++ b/traumadrill/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.24
+
+* Version bump for new base image
+* Update to php83
+
+---
+
 1.23
 
 * Version bump for new base image 14.2

--- a/traumadrill/README.md
+++ b/traumadrill/README.md
@@ -24,7 +24,7 @@ The flavour includes a local ```consul``` agent instance to be available that it
     -E NODENAME=<nodename> \
     -E IP=<IP address of this system> \
     -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-    -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+    -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
     [ -E REMOTELOG=<IP address> ]
   ```
 * Start the jail

--- a/traumadrill/traumadrill.ini
+++ b/traumadrill/traumadrill.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traumadrill"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.23.1"
+version="1.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traumadrill/traumadrill.sh
+++ b/traumadrill/traumadrill.sh
@@ -125,20 +125,20 @@ pkg install -y node_exporter
 step "Install package nginx"
 pkg install -y nginx
 
-step "Install package php82"
-pkg install -y php82
+step "Install package php83"
+pkg install -y php83
 
-step "Install package php82-mbstring"
-pkg install -y php82-mbstring
+step "Install package php83-mbstring"
+pkg install -y php83-mbstring
 
-step "Install package php82-zlib"
-pkg install -y php82-zlib
+step "Install package php83-zlib"
+pkg install -y php83-zlib
 
-step "Install package php82-curl"
-pkg install -y php82-curl
+step "Install package php83-curl"
+pkg install -y php83-curl
 
-step "Install package php82-gd"
-pkg install -y php82-gd
+step "Install package php83-gd"
+pkg install -y php83-gd
 
 step "Install package syslog-ng"
 pkg install -y syslog-ng

--- a/wordpress-nginx-nomad/CHANGELOG.md
+++ b/wordpress-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.20
+
+* Version bump for new base image
+
+---
+
 2.19
 
 * Version bump for new base image 14.2

--- a/wordpress-nginx-nomad/README.md
+++ b/wordpress-nginx-nomad/README.md
@@ -59,7 +59,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/wordpress-nginx-nomad"
         pot = "wordpress-nginx-nomad-amd64-14_2"
-        tag = "2.19.1"
+        tag = "2.20.1"
         command = "/usr/local/bin/cook"
         args = [""]
         mount = [

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="wordpress-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.19.1"
+version="2.20.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.sh
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.sh
@@ -121,6 +121,7 @@ pkg install -y mariadb106-client
 step "Install package postgresql15-client"
 pkg install -y postgresql15-client
 
+# wordpress dependency is php82 still, 2025Q1
 step "Install package php82"
 pkg install -y php82
 

--- a/zincsearch/CHANGELOG.md
+++ b/zincsearch/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.6
+
+* Version bump for new base image
+
+---
+
 0.5
 
 * Version bump for new base image 14.2

--- a/zincsearch/CHECKLIST.md
+++ b/zincsearch/CHECKLIST.md
@@ -18,10 +18,6 @@ Changes to major or minor versions need to be logged in:
 To force a rebuild of the pot image for the potluck site, increment Z of version="x.y.Z" in:
 * `zincsearch.ini`
 
-## Python updates
-Make sure to update python39 and py39-{packagename} in the following files on Python version change:
-* `zincsearch.sh`
-
 ## Zincsearch
 Zincsearch releases are on github at https://github.com/zincsearch/zincsearch/releases
 For new releases the URL, and checksum of extracted binary, must be updated in:

--- a/zincsearch/README.md
+++ b/zincsearch/README.md
@@ -25,7 +25,7 @@ The flavour includes a local ```consul``` agent instance to be available that it
     -E NODENAME=<nodename> \
     -E IP=<IP address of this system> \
     -E CONSULSERVERS="<comma-deliminated list of consul servers>" \
-    -E GOSSIPKEY=<32 byte Base64 key from consul keygen>] \
+    -E GOSSIPKEY=<32 byte Base64 key from consul keygen> \
     -E ZINCUSER=<zincsearch admin user> \
     -E ZINCPASS=<zincsearch admin pass> \
     -E ZINCDATA=<path to store zincsearch files, default /mnt/zinc/data> \

--- a/zincsearch/zincsearch.ini
+++ b/zincsearch/zincsearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="zincsearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.5.1"
+version="0.6.1"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
adminer: Version bump for new base image, update to php83

backuppc-nomad: Version bump for new base image

beast-of-argh: Version bump for new base image

caddy-s3-nomad: Version bump for new base image, update to 2025Q1 for pkg sources

consul: Version bump for new base image

dmarc-report: Version bump for new base image

git-nomad: Version bump for new base image

haproxy-minio: Version bump for new base image

haproxy-sql: Version bump for new base image

hugo-nginx: Version bump for new base image

hugo-nginx-alt: Version bump for new base image

jenkins: Version bump for new base image

mailhhub-potluck: Version bump for new base image, update to 2025Q1 for pkg sources

mariadb: Version bump for new base image

mariadb-galera: Version bump for new base image

mastodon-s3: Version bump for new base image

matrix-synapse: Version bump for new base image

netbox: Version bump for new base image, Update for Netbox version 4.1.10

nextcloud-nginx-nomad: Version bump for new quarterlies

nextcloud-spreed-signalling: Version bump for new base image

nginx-nomad-alt: Version bump for new base image

nginx-rsync-ssh: Version bump for new base image

nginx-s3-nomad: Version bump for new base image

nginx-s3-ssl-nomad: Version bump for new base image

nginx-varnish-ssl-nomad: Version bump for new base image

nomad-server: Version bump for new base image

openldap: Version bump for new base image

opensearch: Version bump for new base image

postfix-backupmx-nomad: Version bump for new base image

postgres-single: Version bump for new base image

rbldnsd: Version bump for new base image, update to php83

redis-single: Version bump for new base image

saltstack: Version bump for new base image

traefik-consul: Version bump for new base image

traumadrill: Version bump for new base image, update to php83

wordpress: Version bump for new base image

zincsearch: Version bump for new base image