### PR TITLE
Version bump for rebuild on pots using latest over quarterly

### DIFF
--- a/caddy-s3-nomad/CHANGELOG.md
+++ b/caddy-s3-nomad/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Version bump for new base image
 * Update to 2025Q1 for pkg sources
 * Update for rsync security issue
+* Fix switch to latest over quarterly
 
 ---
 

--- a/caddy-s3-nomad/README.md
+++ b/caddy-s3-nomad/README.md
@@ -98,7 +98,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/caddy-s3-nomad"
         pot = "caddy-s3-nomad-amd64-14_2"
-        tag = "0.17.2"
+        tag = "0.17.3"
         command = "/usr/local/bin/cook"
         args = ["-h","s3.my.host","-b","bucketname","-d","domainname","-e","email@add.com","-s","yes"]
 		mount = [

--- a/caddy-s3-nomad/caddy-s3-nomad.ini
+++ b/caddy-s3-nomad/caddy-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="caddy-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.17.2"
+version="0.17.3"
 origin="freebsd"
 runs_in_nomad="true"

--- a/caddy-s3-nomad/caddy-s3-nomad.sh
+++ b/caddy-s3-nomad/caddy-s3-nomad.sh
@@ -70,6 +70,8 @@ echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
 #  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
 #    >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
+# added for images with switch to latest
+ASSUME_ALWAYS_YES=yes pkg update
 
 step "Touch /etc/rc.conf"
 touch /etc/rc.conf

--- a/mastodon-s3/CHANGELOG.md
+++ b/mastodon-s3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new image
 * Update for rsync security issue
+* Fix switch to latest over quarterlies
 
 ---
 

--- a/mastodon-s3/mastodon-s3.ini
+++ b/mastodon-s3/mastodon-s3.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mastodon-s3"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.18.2"
+version="0.18.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mastodon-s3/mastodon-s3.sh
+++ b/mastodon-s3/mastodon-s3.sh
@@ -61,13 +61,17 @@ trap 'echo ERROR: $STEP$FAILED | (>&2 tee -a $COOKLOG)' EXIT
 
 step "Bootstrap package repo"
 mkdir -p /usr/local/etc/pkg/repos
-# only modify repo if not already done in base image
-# this is a non-layered image now, with latest package sources
 # shellcheck disable=SC2016
-test -e /usr/local/etc/pkg/repos/FreeBSD.conf || \
-  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
+echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
     >/usr/local/etc/pkg/repos/FreeBSD.conf
+# only modify repo if not already done in base image
+# shellcheck disable=SC2016
+#test -e /usr/local/etc/pkg/repos/FreeBSD.conf || \
+#  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
+#    >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
+# added for images with switch to latest
+ASSUME_ALWAYS_YES=yes pkg update
 
 step "Touch /etc/rc.conf"
 touch /etc/rc.conf

--- a/nextcloud-nginx-nomad/CHANGELOG.md
+++ b/nextcloud-nginx-nomad/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new quarterlies
 * Update for rsync security issue
+* Fix switch to latest over quarterly
 
 ---
 

--- a/nextcloud-nginx-nomad/README.md
+++ b/nextcloud-nginx-nomad/README.md
@@ -246,7 +246,7 @@ job "nextcloud" {
       config {
         image = "https://potluck.honeyguide.net/nextcloud-nginx-nomad"
         pot = "nextcloud-nginx-nomad-amd64-14_2"
-        tag = "0.114"
+        tag = "0.115"
         command = "/usr/local/bin/cook"
         args = ["-d","/mnt/filestore","-s","host:ip"]
         copy = [

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.114"
+version="0.115"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.sh
@@ -70,6 +70,8 @@ echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
 #  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
 #    >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
+# added for images with switch to latest
+ASSUME_ALWAYS_YES=yes pkg update
 
 step "Touch /etc/rc.conf"
 touch /etc/rc.conf

--- a/nginx-s3-nomad/CHANGELOG.md
+++ b/nginx-s3-nomad/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Update for rsync security issue
+* Fix switch to latest over quarterly
 
 ---
 

--- a/nginx-s3-nomad/README.md
+++ b/nginx-s3-nomad/README.md
@@ -96,7 +96,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
         pot = "nginx-s3-nomad-amd64-14_2"
-        tag = "0.23.2"
+        tag = "0.23.3"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-x","bucketname","-s","yes"]
         port_map = {
@@ -150,7 +150,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
         pot = "nginx-s3-nomad-amd64-14_2"
-        tag = "0.23.2"
+        tag = "0.23.3"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-c","10.0.0.4","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-nomad/nginx-s3-nomad.ini
+++ b/nginx-s3-nomad/nginx-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.23.2"
+version="0.23.3"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-s3-nomad/nginx-s3-nomad.sh
+++ b/nginx-s3-nomad/nginx-s3-nomad.sh
@@ -70,6 +70,8 @@ echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
 #  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
 #    >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
+# added for images with switch to latest
+ASSUME_ALWAYS_YES=yes pkg update
 
 step "Touch /etc/rc.conf"
 touch /etc/rc.conf

--- a/nginx-s3-ssl-nomad/CHANGELOG.md
+++ b/nginx-s3-ssl-nomad/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Update for rsync security issue
+* Fix switch to latest over quarterly
 
 ---
 

--- a/nginx-s3-ssl-nomad/README.md
+++ b/nginx-s3-ssl-nomad/README.md
@@ -98,7 +98,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.12.2"
+        tag = "0.12.3"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -152,7 +152,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.12.2"
+        tag = "0.12.3"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -206,7 +206,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.12.2"
+        tag = "0.12.3"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-g","10.0.0.4:9000","-h","10.0.0.5:9000","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.12.2"
+version="0.12.3"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.sh
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.sh
@@ -70,6 +70,8 @@ echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
 #  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
 #    >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
+# added for images with switch to latest
+ASSUME_ALWAYS_YES=yes pkg update
 
 step "Touch /etc/rc.conf"
 touch /etc/rc.conf

--- a/nginx-varnish-ssl-nomad/CHANGELOG.md
+++ b/nginx-varnish-ssl-nomad/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Update for rsync security issue
+* Fix switch to latest over quarterly
 
 ---
 

--- a/nginx-varnish-ssl-nomad/README.md
+++ b/nginx-varnish-ssl-nomad/README.md
@@ -69,7 +69,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-varnish-ssl-nomad"
         pot = "nginx-varnish-ssl-nomad-amd64-14_2"
-        tag = "0.3.2"
+        tag = "0.3.3"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-s","10.0.0.2:8080","-b","bucketname"]
         port_map = {

--- a/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
+++ b/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-varnish-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.3.2"
+version="0.3.3"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.sh
+++ b/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.sh
@@ -70,6 +70,8 @@ echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
 #  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
 #    >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
+# added for images with switch to latest
+ASSUME_ALWAYS_YES=yes pkg update
 
 step "Touch /etc/rc.conf"
 touch /etc/rc.conf

--- a/pixelfed/CHANGELOG.md
+++ b/pixelfed/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.9
+
+* Update for new base image
+* Fix switch to latest over quarterly
+
+---
+
 0.8
 
 * Version bump for new base image 14.2

--- a/pixelfed/pixelfed.ini
+++ b/pixelfed/pixelfed.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="pixelfed"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.8.2"
+version="0.9.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/pixelfed/pixelfed.sh
+++ b/pixelfed/pixelfed.sh
@@ -61,12 +61,17 @@ trap 'echo ERROR: $STEP$FAILED | (>&2 tee -a $COOKLOG)' EXIT
 
 step "Bootstrap package repo"
 mkdir -p /usr/local/etc/pkg/repos
+# shellcheck disable=SC2016
+echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
+    >/usr/local/etc/pkg/repos/FreeBSD.conf
 # only modify repo if not already done in base image
 # shellcheck disable=SC2016
-test -e /usr/local/etc/pkg/repos/FreeBSD.conf || \
-  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
-    >/usr/local/etc/pkg/repos/FreeBSD.conf
+#test -e /usr/local/etc/pkg/repos/FreeBSD.conf || \
+#  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
+#    >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
+# added for images with switch to latest
+ASSUME_ALWAYS_YES=yes pkg update
 
 step "Touch /etc/rc.conf"
 touch /etc/rc.conf

--- a/traumadrill/CHANGELOG.md
+++ b/traumadrill/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Version bump for new base image
 * Update to php83
 * Update for rsync security issue
+* Switch to latest repo as stress-ng missing from quarterlies
 
 ---
 

--- a/traumadrill/traumadrill.ini
+++ b/traumadrill/traumadrill.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traumadrill"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.24.2"
+version="1.24.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traumadrill/traumadrill.sh
+++ b/traumadrill/traumadrill.sh
@@ -61,12 +61,19 @@ trap 'echo ERROR: $STEP$FAILED | (>&2 tee -a $COOKLOG)' EXIT
 
 step "Bootstrap package repo"
 mkdir -p /usr/local/etc/pkg/repos
+#
+# switch to latest as stress-ng missing from quarterlies
+# shellcheck disable=SC2016
+echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
+    >/usr/local/etc/pkg/repos/FreeBSD.conf
 # only modify repo if not already done in base image
 # shellcheck disable=SC2016
-test -e /usr/local/etc/pkg/repos/FreeBSD.conf || \
-  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
-    >/usr/local/etc/pkg/repos/FreeBSD.conf
+#test -e /usr/local/etc/pkg/repos/FreeBSD.conf || \
+#  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
+#    >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
+# added for images with switch to latest
+ASSUME_ALWAYS_YES=yes pkg update
 
 step "Touch /etc/rc.conf"
 touch /etc/rc.conf

--- a/wordpress-nginx-nomad/CHANGELOG.md
+++ b/wordpress-nginx-nomad/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Version bump for new base image
 * Update for rsync security issue
+* Fix switch to latest over quarterly
 
 ---
 

--- a/wordpress-nginx-nomad/README.md
+++ b/wordpress-nginx-nomad/README.md
@@ -59,7 +59,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/wordpress-nginx-nomad"
         pot = "wordpress-nginx-nomad-amd64-14_2"
-        tag = "2.20.2"
+        tag = "2.20.3"
         command = "/usr/local/bin/cook"
         args = [""]
         mount = [

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="wordpress-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.20.2"
+version="2.20.3"
 origin="freebsd"
 runs_in_nomad="true"

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.sh
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.sh
@@ -70,6 +70,8 @@ echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
 #  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
 #    >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
+# added for images with switch to latest
+ASSUME_ALWAYS_YES=yes pkg update
 
 step "Touch /etc/rc.conf"
 touch /etc/rc.conf


### PR DESCRIPTION
Caddy-s3-nomad: Fix switch to latest over quarterly

Mastodon: Fix switch to latest over quarterly

Nginx-s3-nomad: Fix switch to latest over quarterly

Nginx-s3-ssl-nomad: Fix switch to latest over quarterly

Nginx-varnish-ssl-nomad: Fix switch to latest over quarterly

Pixelfed: version bump for new base image, fix switch to latest over quarterly

Traumadrill: Switch to latest repo as stress-ng missing from quarterlies

Wordpress: Fix switch to latest over quarterly