### PR TITLE
postgresql-patroni: Revert to using postgresql13

### DIFF
--- a/postgresql-patroni/CHANGELOG.md
+++ b/postgresql-patroni/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.7
+
+* Return to using postgresql13
+
+---
+
 2.6
 
 * Version bump for new base image 14.2

--- a/postgresql-patroni/postgresql-patroni.ini
+++ b/postgresql-patroni/postgresql-patroni.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postgresql-patroni"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.6.1"
+version="2.7.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/postgresql-patroni/postgresql-patroni.sh
+++ b/postgresql-patroni/postgresql-patroni.sh
@@ -122,10 +122,10 @@ step "Install package syslog-ng"
 pkg install -y syslog-ng
 
 step "Install package postgresql-server"
-pkg install -y postgresql15-server
+pkg install -y postgresql13-server
 
 step "Install package postgresql-client"
-pkg install -y postgresql15-client
+pkg install -y postgresql13-client
 
 step "Install package postgresql-contrib"
 pkg install -y postgresql13-contrib


### PR DESCRIPTION
This was changed to postgresql15 at some point without any mention in commits/release (probably a side-effect of something).

Switching patroni major versions is a complex task, so updating the image would render the affected system unusable/in need of a manual update (e.g., database directory changes to /var/db/postgres/data15). See https://forums.freebsd.org/threads/upgrading-postgresql-database-from-11-to-use-postgresql-15.94416/ for an example.
