### PR TITLE
Multiple flavours: version bump for new base image

### DIFF
--- a/adminer/CHANGELOG.md
+++ b/adminer/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.12
+
+* Version bump for new base image
+
+---
+
 0.11
 
 * Version bump for new base image

--- a/adminer/adminer.ini
+++ b/adminer/adminer.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="adminer"
 author="Deividas Gedgaudas"
-version="0.11.2"
+version="0.12.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/backuppc-nomad/CHANGELOG.md
+++ b/backuppc-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.21
+
+* Version bump for new base image
+
+---
+
 1.20
 
 * Version bump for new base image

--- a/backuppc-nomad/README.md
+++ b/backuppc-nomad/README.md
@@ -64,7 +64,7 @@ job "backuppc" {
       config {
         image = "https://potluck.honeyguide.net/backuppc-nomad"
         pot = "backuppc-nomad-amd64-14_2"
-        tag = "1.20.2"
+        tag = "1.21.1"
         command = "/usr/local/bin/cook"
         args = ["-p","myadminpassword"]
         mount = [

--- a/backuppc-nomad/backuppc-nomad.d/local/bin/cook
+++ b/backuppc-nomad/backuppc-nomad.d/local/bin/cook
@@ -79,7 +79,7 @@ done
 ## Provision image
 ########################################################################
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 log "Configure Samba"
 configure-samba.sh

--- a/backuppc-nomad/backuppc-nomad.d/local/share/cook/bin/configure-apache.sh
+++ b/backuppc-nomad/backuppc-nomad.d/local/share/cook/bin/configure-apache.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 #SCRIPT=$(readlink -f "$0")
 #TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/backuppc-nomad/backuppc-nomad.d/local/share/cook/bin/configure-backuppc.sh
+++ b/backuppc-nomad/backuppc-nomad.d/local/share/cook/bin/configure-backuppc.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/backuppc-nomad/backuppc-nomad.d/local/share/cook/bin/configure-backuppc.sh
+++ b/backuppc-nomad/backuppc-nomad.d/local/share/cook/bin/configure-backuppc.sh
@@ -49,4 +49,3 @@ pwd_mkdb -p /etc/master.passwd
 
 # enable backuppc
 service backuppc enable
-

--- a/backuppc-nomad/backuppc-nomad.d/local/share/cook/bin/configure-samba.sh
+++ b/backuppc-nomad/backuppc-nomad.d/local/share/cook/bin/configure-samba.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/backuppc-nomad/backuppc-nomad.ini
+++ b/backuppc-nomad/backuppc-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="backuppc-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.20.2"
+version="1.21.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/beast-of-argh/CHANGELOG.md
+++ b/beast-of-argh/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.25
+
+* Version bump for new base image
+
+---
+
 0.24
 
 * Version bump for new base image

--- a/beast-of-argh/beast-of-argh.ini
+++ b/beast-of-argh/beast-of-argh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="beast-of-argh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.24.4"
+version="0.25.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/caddy-s3-nomad/CHANGELOG.md
+++ b/caddy-s3-nomad/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.18
 
 * Version bump for new base image
+* Add certificate expiry scripts for alertmanager notices
 
 ---
 

--- a/caddy-s3-nomad/CHANGELOG.md
+++ b/caddy-s3-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.18
+
+* Version bump for new base image
+
+---
+
 0.17
 
 * Version bump for new base image

--- a/caddy-s3-nomad/README.md
+++ b/caddy-s3-nomad/README.md
@@ -98,7 +98,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/caddy-s3-nomad"
         pot = "caddy-s3-nomad-amd64-14_2"
-        tag = "0.17.3"
+        tag = "0.18.1"
         command = "/usr/local/bin/cook"
         args = ["-h","s3.my.host","-b","bucketname","-d","domainname","-e","email@add.com","-s","yes"]
 		mount = [

--- a/caddy-s3-nomad/README.md
+++ b/caddy-s3-nomad/README.md
@@ -59,7 +59,9 @@ EMAIL is the email address to use for SSL certificate registration. You can set 
 
 SERVER is the S3 server. You can also set this with the `-h` parameter followed by the S3 host..
 
-SELFSIGNED enables obtaining the self-signed CA certicate into the local store. Enable with `-s` and any value.
+SELFSIGNED is optional and enables obtaining the self-signed CA certicate from minio into the local store. Enable with `-s` and any value.
+
+ALERTIP is an optional parameter for the IP address of an `alertmanager` instance, for sending notices of certificate expiry.
 
 # Nomad Job File Samples
 
@@ -100,7 +102,7 @@ job "example" {
         pot = "caddy-s3-nomad-amd64-14_2"
         tag = "0.18.1"
         command = "/usr/local/bin/cook"
-        args = ["-h","s3.my.host","-b","bucketname","-d","domainname","-e","email@add.com","-s","yes"]
+        args = ["-h","s3.my.host","-b","bucketname","-d","domainname","-e","email@add.com","-s","yes","-x","alertmanager-ip"]
 		mount = [
           "/path/to/dataset/caddyimage:/mnt"
         ]

--- a/caddy-s3-nomad/caddy-s3-nomad.d/local/bin/cook
+++ b/caddy-s3-nomad/caddy-s3-nomad.d/local/bin/cook
@@ -45,7 +45,7 @@ fi
 ## Convert parameters to variables if passed (overwrite environment)
 ########################################################################
 OPTIND=1
-while getopts b:d:e:h:s: option
+while getopts b:d:e:h:s:x: option
 do
     case "${option}"
     in
@@ -64,6 +64,9 @@ do
       s) SELFSIGNHOST=${OPTARG}
          export SELFSIGNHOST
          ;;
+      x) ALERTIP=${OPTARG}
+         export ALERTIP
+         ;;
     esac
 done
 shift "$((OPTIND-1))"
@@ -73,7 +76,7 @@ shift "$((OPTIND-1))"
 ########################################################################
 
 required_args="SERVER DOMAIN BUCKET EMAIL"
-optional_args="SELFSIGNHOST"
+optional_args="SELFSIGNHOST ALERTIP"
 
 for var in $required_args; do
   if [ -z "$(eval echo "\${$var}")" ]; then
@@ -92,11 +95,11 @@ done
 ## Provision image
 ########################################################################
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "$SELFSIGNHOST" ]; then
-    log "Configure self-signed certicate store"
-    configure-selfsigned.sh
+	log "Configure self-signed certicate store"
+	configure-selfsigned.sh
 fi
 
 log "Configure access credentials file"
@@ -107,6 +110,11 @@ configure-acme.sh
 
 log "Configure caddy with one S3 server"
 configure-caddy.sh
+
+if [ -n "$ALERTIP" ]; then
+	log "Configure certificate validity scripts"
+	configure-scripts.sh
+fi
 
 log "Start caddy"
 timeout --foreground 120 \

--- a/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-access.sh
+++ b/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-access.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-acme.sh
+++ b/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-acme.sh
@@ -9,11 +9,10 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
-
 
 # make directories if they don't exist
 mkdir -p /mnt/acme

--- a/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-caddy.sh
+++ b/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-caddy.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-scripts.sh
+++ b/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-scripts.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+if [ -e /root/.env.cook ]; then
+    . /root/.env.cook
+fi
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+export PATH="/usr/local/bin:$PATH"
+
+SCRIPT=$(readlink -f "$0")
+TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
+
+# shellcheck disable=SC3003,SC2039
+# safe(r) separator for sed
+sep=$'\001'
+
+# make sure we have a /root/bin directory
+mkdir -p /root/bin
+
+# add check-cert.sh script
+< "$TEMPLATEPATH/check-cert.sh.in" \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/check-cert.sh
+
+# set executable permissions
+chmod +x /root/bin/check-cert.sh
+
+# add sendcertalert.sh script
+< "$TEMPLATEPATH/sendcertalert.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertalert.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertalert.sh
+
+# add sendcertexpired.sh script
+< "$TEMPLATEPATH/sendcertexpired.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$ALERTIP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertexpired.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertexpired.sh
+
+# add check-cert.sh script to /etc/crontab
+echo "# Check SSL certificate every day" >> /etc/crontab
+echo "0	12	*	*	*	root	/root/bin/check-cert.sh /usr/local/etc/ssl/fullchain.cer > /dev/null 2>&1" >> /etc/crontab

--- a/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-selfsigned.sh
+++ b/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/bin/configure-selfsigned.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # configure self-signed certificates by adding minio certicate to local CA store
 echo "" |/usr/bin/openssl s_client -showcerts -noservername -connect "$SERVER:9000" |/usr/bin/openssl x509 -outform PEM > /tmp/cert.pem

--- a/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/templates/check-cert.sh.in
+++ b/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/templates/check-cert.sh.in
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Add to /etc/crontab
+#
+# # Check certificate for %%domain%%
+# 0	12	*	*	*	root	/root/bin/check-cert.sh /path/to/certificate.crt > /dev/null 2>&1
+#
+
+# Check if a certificate path is provided
+if [ -z "$1" ]; then
+	echo "Usage: $0 /path/to/certificate.crt"
+	exit 1
+fi
+
+cert_file="$1"
+
+# Check if the certificate file exists
+if [ ! -f "$cert_file" ]; then
+	echo "Error: File '$cert_file' not found."
+	exit 1
+fi
+
+# Extract the expiration date from the certificate
+expiry_date=$(openssl x509 -noout -enddate -in "$cert_file" | awk -F'=' '{print $2}')
+
+# Convert the expiration date to seconds since epoch
+expiry_epoch=$(date -j -f "%b %e %T %Y %Z" "$expiry_date" "+%s")
+
+# Get the current date in seconds since epoch
+current_epoch=$(date -u "+%s")
+
+# Calculate the difference in seconds
+diff_seconds=$((expiry_epoch - current_epoch))
+
+# Convert 10 days to seconds (10 * 24 * 60 * 60)
+ten_days_seconds=$((10 * 24 * 60 * 60))
+
+# Check if the difference is within 10 days
+if [ "$diff_seconds" -le "$ten_days_seconds" ] && [ "$diff_seconds" -gt 0 ]; then
+	echo "The certificate will expire within 10 days."
+	if [ -x /root/bin/sendcertalert.sh ]; then
+		/root/bin/sendcertalert.sh
+	fi
+elif [ "$diff_seconds" -le 0 ]; then
+	echo "The certificate has already expired."
+	if [ -x /root/bin/sendcertexpired.sh ]; then
+		/root/bin/sendcertexpired.sh
+	fi
+else
+	echo "The certificate is valid for more than 10 days."
+fi

--- a/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/templates/sendcertalert.sh.in
+++ b/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/templates/sendcertalert.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpiry",
+      "instance": "caddy-s3-nomad:12345",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% will expire in 10 days."
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/templates/sendcertexpired.sh.in
+++ b/caddy-s3-nomad/caddy-s3-nomad.d/local/share/cook/templates/sendcertexpired.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpired",
+      "instance": "caddy-s3-nomad:12345",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% has expired.",
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/caddy-s3-nomad/caddy-s3-nomad.ini
+++ b/caddy-s3-nomad/caddy-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="caddy-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.17.3"
+version="0.18.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.24
+
+* Version bump for new base image
+
+---
+
 2.23
 
 * Version bump for new base image

--- a/consul/consul.ini
+++ b/consul/consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.23.1"
+version="2.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/dmarc-report/CHANGELOG.md
+++ b/dmarc-report/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.20
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.19
 
 * Version bump for new base image

--- a/dmarc-report/dmarc-report.d/local/bin/cook
+++ b/dmarc-report/dmarc-report.d/local/bin/cook
@@ -84,7 +84,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-consul.sh
+++ b/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-nginx.sh
+++ b/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-parsedmarc.sh
+++ b/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-parsedmarc.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # Adapt config files
 SCRIPT=$(readlink -f "$0")

--- a/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-report.sh
+++ b/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-report.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/dmarc-report/dmarc-report.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/dmarc-report/dmarc-report.ini
+++ b/dmarc-report/dmarc-report.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="dmarc-report"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.19.2"
+version="0.20.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/git-nomad/CHANGELOG.md
+++ b/git-nomad/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.23
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 1.22
 
 * Version bump for new base image

--- a/git-nomad/README.md
+++ b/git-nomad/README.md
@@ -53,7 +53,7 @@ job "examplegit" {
       config {
         image = "https://potluck.honeyguide.net/git-nomad"
         pot = "git-nomad-amd64-14_2"
-        tag = "1.22.2"
+        tag = "1.23.1"
         command = "/usr/local/bin/cook"
         args = ["-n","gitnomad"]
 

--- a/git-nomad/git-nomad.d/local/bin/cook
+++ b/git-nomad/git-nomad.d/local/bin/cook
@@ -80,7 +80,7 @@ done
 ## Provision image
 ########################################################################
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 log "Configure git user and ssh"
 configure-ssh.sh

--- a/git-nomad/git-nomad.d/local/share/cook/bin/configure-ssh.sh
+++ b/git-nomad/git-nomad.d/local/share/cook/bin/configure-ssh.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 #SCRIPT=$(readlink -f "$0")
 #TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/git-nomad/git-nomad.ini
+++ b/git-nomad/git-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="git-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.22.1"
+version="1.23.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/haproxy-minio/CHANGELOG.md
+++ b/haproxy-minio/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.12
+
+* Version bump for new base image
+* Quote PATH statements
+* Fix error in CHECKLIST.md
+
+---
+
 0.11
 
 * Version bump for new base image

--- a/haproxy-minio/CHECKLIST.md
+++ b/haproxy-minio/CHECKLIST.md
@@ -18,9 +18,5 @@ Changes to major or minor versions need to be logged in:
 To force a rebuild of the pot image for the potluck site, increment Z of version="x.y.Z" in:
 * `haproxy-minio.ini`
 
-## Changes in mariadb-client version
-When `mariadb-client` version increments, make sure to update the package install command in:
-* `haproxy-minio.sh`
-
 ## Shellcheck
 Was `shellcheck` run on all applicable shell files?

--- a/haproxy-minio/haproxy-minio.d/local/bin/cook
+++ b/haproxy-minio/haproxy-minio.d/local/bin/cook
@@ -86,7 +86,7 @@ timeout --foreground 10 \
 killall -9 consul || true
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-consul.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-consul.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-haproxy-1.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-haproxy-1.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # make directories
 mkdir -p /usr/local/etc/haproxy

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-haproxy-2.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-haproxy-2.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # make directories
 mkdir -p /usr/local/etc/haproxy

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-haproxy-3.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-haproxy-3.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # make directories
 mkdir -p /usr/local/etc/haproxy

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-haproxy-4.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-haproxy-4.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # make directories
 mkdir -p /usr/local/etc/haproxy

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-local-unbound.sh
@@ -8,7 +8,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-selfsigned.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-selfsigned.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # configure self-signed certificates by adding minio certicate to local CA store
 echo "" |/usr/bin/openssl s_client -showcerts -noservername -connect "$SERVERONE:$SERVERONEPORT" |/usr/bin/openssl x509 -outform PEM > /tmp/cert.pem

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-ssl.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-ssl.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # shellcheck disable=SC2269
 DOMAIN="$DOMAIN"

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-varnish-exporter.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-varnish-exporter.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # no steps needed really
 

--- a/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-varnish.sh
+++ b/haproxy-minio/haproxy-minio.d/local/share/cook/bin/configure-varnish.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/haproxy-minio/haproxy-minio.ini
+++ b/haproxy-minio/haproxy-minio.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-minio"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.11.2"
+version="0.12.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy-sql/CHANGELOG.md
+++ b/haproxy-sql/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.17
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.16
 
 * Version bump for new base image

--- a/haproxy-sql/haproxy-sql.d/local/bin/cook
+++ b/haproxy-sql/haproxy-sql.d/local/bin/cook
@@ -83,7 +83,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-consul.sh
+++ b/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-haproxy-2.sh
+++ b/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-haproxy-2.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # make directories
 mkdir -p /usr/local/etc/haproxy

--- a/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-haproxy-3.sh
+++ b/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-haproxy-3.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # make directories
 mkdir -p /usr/local/etc/haproxy

--- a/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/haproxy-sql/haproxy-sql.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/haproxy-sql/haproxy-sql.ini
+++ b/haproxy-sql/haproxy-sql.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-sql"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.16.2"
+version="0.17.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/hugo-nginx-alt/CHANGELOG.md
+++ b/hugo-nginx-alt/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.12
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.11
 
 * Version bump for new base image

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/bin/cook
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/bin/cook
@@ -119,7 +119,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-consul.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-customfile.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-customfile.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # if the copied-in customfile exists, extract to sitename
 if [ -f /root/customfile.tgz ]; then

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-goaccess.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-goaccess.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-hugo.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-hugo.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # final perms check
 chown -R www:www "/var/db/$SITENAME"

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-minio.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-minio.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:"$PATH"
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-nginx.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-site-post.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-site-post.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # link in /usr/local/www/SITENAME to /var/db/SITENAME
 ln -s "/var/db/$SITENAME/public" "/usr/local/www/$SITENAME"

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-site-pre.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-site-pre.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-ssh-keys.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-ssh-keys.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # create directories and set permissions
 mkdir -p /root/.ssh

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-theme.sh
+++ b/hugo-nginx-alt/hugo-nginx-alt.d/local/share/cook/bin/configure-theme.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # this will run an imported script copied into /root/customscript.sh
 # if the file exists.

--- a/hugo-nginx-alt/hugo-nginx-alt.ini
+++ b/hugo-nginx-alt/hugo-nginx-alt.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx-alt"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.11.2"
+version="0.12.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/hugo-nginx/CHANGELOG.md
+++ b/hugo-nginx/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.23
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.22
 
 * Version bump for new base image

--- a/hugo-nginx/hugo-nginx.d/local/bin/cook
+++ b/hugo-nginx/hugo-nginx.d/local/bin/cook
@@ -85,7 +85,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-consul.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-cron.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-cron.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # setup cronjob for once a day 3am
 echo "0 3 * * *   root   /root/bin/mirrorsync.sh" >> /etc/crontab

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-customfile.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-customfile.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # if the copied-in customfile exists, extract to sitename
 if [ -f /root/customfile.tgz ]; then

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-goaccess.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-goaccess.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-hugo.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-hugo.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # final perms check
 chown -R www:www "/mnt/$SITENAME"

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-minio.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-minio.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:"$PATH"
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-nginx.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-site-post.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-site-post.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # set permissions so jenkins user can write files from jenkins image
 chmod 777 "/mnt/$SITENAME"

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-site-pre.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-site-pre.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # setup hugo pre-steps
 cd /mnt

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-ssh-keys.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-ssh-keys.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # create root ssh keys
 mkdir -p /root/.ssh

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-sshd.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-sshd.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-theme.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-theme.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-userkeys.sh
+++ b/hugo-nginx/hugo-nginx.d/local/share/cook/bin/configure-userkeys.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # check if copied-in file for jenkins key exists, and if so, copy it to authorized_keys
 if [ -f /root/jenkins.pub ]; then

--- a/hugo-nginx/hugo-nginx.ini
+++ b/hugo-nginx/hugo-nginx.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.22.2"
+version="0.23.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/jenkins/CHANGELOG.md
+++ b/jenkins/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.23
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.22
 
 * Version bump for new base image

--- a/jenkins/jenkins.d/local/bin/cook
+++ b/jenkins/jenkins.d/local/bin/cook
@@ -82,7 +82,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/jenkins/jenkins.d/local/share/cook/bin/configure-consul.sh
+++ b/jenkins/jenkins.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/jenkins/jenkins.d/local/share/cook/bin/configure-jenkins.sh
+++ b/jenkins/jenkins.d/local/share/cook/bin/configure-jenkins.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 case "$RUNTYPE" in
 

--- a/jenkins/jenkins.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/jenkins/jenkins.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/jenkins/jenkins.d/local/share/cook/bin/configure-minio.sh
+++ b/jenkins/jenkins.d/local/share/cook/bin/configure-minio.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:"$PATH"
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/jenkins/jenkins.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/jenkins/jenkins.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/jenkins/jenkins.ini
+++ b/jenkins/jenkins.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="jenkins"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.22.2"
+version="0.23.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mailhub-potluck/CHANGELOG.md
+++ b/mailhub-potluck/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.21
+
+* Version bump for new base image
+* Add certificate expiry notices to alertmanager host
+
+---
+
 0.20
 
 * Version bump for new base image

--- a/mailhub-potluck/mailhub-potluck.d/local/bin/cook
+++ b/mailhub-potluck/mailhub-potluck.d/local/bin/cook
@@ -148,6 +148,10 @@ configure-dovecot.sh
 log "Configure clamav"
 configure-clamav.sh
 
+# configure certificate expiry checks
+log "Configure certificate validity scripts"
+configure-scripts.sh
+
 ### start services
 
 # start freshclam and update

--- a/mailhub-potluck/mailhub-potluck.d/local/share/cook/bin/configure-scripts.sh
+++ b/mailhub-potluck/mailhub-potluck.d/local/share/cook/bin/configure-scripts.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+if [ -e /root/.env.cook ]; then
+    . /root/.env.cook
+fi
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+export PATH="/usr/local/bin:$PATH"
+
+SCRIPT=$(readlink -f "$0")
+TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
+
+# shellcheck disable=SC3003,SC2039
+# safe(r) separator for sed
+sep=$'\001'
+
+# make sure we have a /root/bin directory
+mkdir -p /root/bin
+
+# add check-cert.sh script
+< "$TEMPLATEPATH/check-cert.sh.in" \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/check-cert.sh
+
+# set executable permissions
+chmod +x /root/bin/check-cert.sh
+
+# add sendcertalert.sh script
+< "$TEMPLATEPATH/sendcertalert.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertalert.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertalert.sh
+
+# add sendcertexpired.sh script
+< "$TEMPLATEPATH/sendcertexpired.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertexpired.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertexpired.sh
+
+# add check-cert.sh script to /etc/crontab
+echo "# Check SSL certificate every day" >> /etc/crontab
+echo "0	12	*	*	*	root	/root/bin/check-cert.sh /usr/local/etc/ssl/fullchain.cer > /dev/null 2>&1" >> /etc/crontab

--- a/mailhub-potluck/mailhub-potluck.d/local/share/cook/templates/check-cert.sh.in
+++ b/mailhub-potluck/mailhub-potluck.d/local/share/cook/templates/check-cert.sh.in
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Add to /etc/crontab
+#
+# # Check certificate for %%domain%%
+# 0	12	*	*	*	root	/root/bin/check-cert.sh /path/to/certificate.crt > /dev/null 2>&1
+#
+
+# Check if a certificate path is provided
+if [ -z "$1" ]; then
+	echo "Usage: $0 /path/to/certificate.crt"
+	exit 1
+fi
+
+cert_file="$1"
+
+# Check if the certificate file exists
+if [ ! -f "$cert_file" ]; then
+	echo "Error: File '$cert_file' not found."
+	exit 1
+fi
+
+# Extract the expiration date from the certificate
+expiry_date=$(openssl x509 -noout -enddate -in "$cert_file" | awk -F'=' '{print $2}')
+
+# Convert the expiration date to seconds since epoch
+expiry_epoch=$(date -j -f "%b %e %T %Y %Z" "$expiry_date" "+%s")
+
+# Get the current date in seconds since epoch
+current_epoch=$(date -u "+%s")
+
+# Calculate the difference in seconds
+diff_seconds=$((expiry_epoch - current_epoch))
+
+# Convert 10 days to seconds (10 * 24 * 60 * 60)
+ten_days_seconds=$((10 * 24 * 60 * 60))
+
+# Check if the difference is within 10 days
+if [ "$diff_seconds" -le "$ten_days_seconds" ] && [ "$diff_seconds" -gt 0 ]; then
+	echo "The certificate will expire within 10 days."
+	if [ -x /root/bin/sendcertalert.sh ]; then
+		/root/bin/sendcertalert.sh
+	fi
+elif [ "$diff_seconds" -le 0 ]; then
+	echo "The certificate has already expired."
+	if [ -x /root/bin/sendcertexpired.sh ]; then
+		/root/bin/sendcertexpired.sh
+	fi
+else
+	echo "The certificate is valid for more than 10 days."
+fi

--- a/mailhub-potluck/mailhub-potluck.d/local/share/cook/templates/sendcertalert.sh.in
+++ b/mailhub-potluck/mailhub-potluck.d/local/share/cook/templates/sendcertalert.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpiry",
+      "instance": "%%ip%%:25",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% will expire in 10 days."
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/mailhub-potluck/mailhub-potluck.d/local/share/cook/templates/sendcertexpired.sh.in
+++ b/mailhub-potluck/mailhub-potluck.d/local/share/cook/templates/sendcertexpired.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpired",
+      "instance": "%%ip%%:25",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% has expired.",
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/mailhub-potluck/mailhub-potluck.ini
+++ b/mailhub-potluck/mailhub-potluck.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mailhub-potluck"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.4"
+version="0.21.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mariadb-galera/CHANGELOG.md
+++ b/mariadb-galera/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.16
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.15
 
 * Version bump for new base image

--- a/mariadb-galera/mariadb-galera.d/local/bin/cook
+++ b/mariadb-galera/mariadb-galera.d/local/bin/cook
@@ -94,7 +94,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-admin-tools.sh
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-admin-tools.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # make a directory for the tools
 mkdir -p /root/bin

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-consul.sh
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-haproxyuser.sh
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-haproxyuser.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 #SCRIPT=$(readlink -f "$0")
 #TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-mariadb-primary.sh
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-mariadb-primary.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-mariadb.sh
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-mariadb.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-mysqld-exporter-primary.sh
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-mysqld-exporter-primary.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-mysqld-exporter.sh
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-mysqld-exporter.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/mariadb-galera/mariadb-galera.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb-galera/mariadb-galera.ini
+++ b/mariadb-galera/mariadb-galera.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb-galera"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.15.2"
+version="0.16.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,3 +1,10 @@
+4.13
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 4.12
 
 * Version bump for new base image

--- a/mariadb/mariadb.d/local/bin/cook
+++ b/mariadb/mariadb.d/local/bin/cook
@@ -117,7 +117,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/mariadb/mariadb.d/local/share/cook/bin/configure-admin-tools.sh
+++ b/mariadb/mariadb.d/local/share/cook/bin/configure-admin-tools.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # make a directory for the tools
 mkdir -p /root/bin

--- a/mariadb/mariadb.d/local/share/cook/bin/configure-consul.sh
+++ b/mariadb/mariadb.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb/mariadb.d/local/share/cook/bin/configure-haproxyuser.sh
+++ b/mariadb/mariadb.d/local/share/cook/bin/configure-haproxyuser.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 #SCRIPT=$(readlink -f "$0")
 #TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb/mariadb.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/mariadb/mariadb.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/mariadb/mariadb.d/local/share/cook/bin/configure-mariadb.sh
+++ b/mariadb/mariadb.d/local/share/cook/bin/configure-mariadb.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb/mariadb.d/local/share/cook/bin/configure-mysqld-exporter.sh
+++ b/mariadb/mariadb.d/local/share/cook/bin/configure-mysqld-exporter.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb/mariadb.d/local/share/cook/bin/configure-replication.sh
+++ b/mariadb/mariadb.d/local/share/cook/bin/configure-replication.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 #SCRIPT=$(readlink -f "$0")
 #TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb/mariadb.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/mariadb/mariadb.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mariadb/mariadb.ini
+++ b/mariadb/mariadb.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="4.12.2"
+version="4.13.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mastodon-s3/CHANGELOG.md
+++ b/mastodon-s3/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.19
+
+* Version bump for new image with pkg 2
+* Add certificate expiry checks to alertmanager
+* Quote PATH statements
+
+---
+
 0.18
 
 * Version bump for new image

--- a/mastodon-s3/mastodon-s3.d/local/bin/cook
+++ b/mastodon-s3/mastodon-s3.d/local/bin/cook
@@ -239,8 +239,10 @@ else
 	log "Configure acme.sh"
 	configure-acme.sh
 
-	log "Configure certificate validity scripts"
-	configure-scripts.sh
+	if [ -n "${REMOTELOG}" ]; then
+		log "Configure certificate validity scripts"
+		configure-scripts.sh
+	fi
 fi
 
 log "Configure nginx"

--- a/mastodon-s3/mastodon-s3.d/local/bin/cook
+++ b/mastodon-s3/mastodon-s3.d/local/bin/cook
@@ -192,7 +192,7 @@ else
 fi
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 # stop services
 timeout --foreground 10 \
@@ -238,6 +238,9 @@ if [ -n "${PVTCERT}" ]; then
 else
 	log "Configure acme.sh"
 	configure-acme.sh
+
+	log "Configure certificate validity scripts"
+	configure-scripts.sh
 fi
 
 log "Configure nginx"

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-acme.sh
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-acme.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-blackbox-exporter.sh
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-blackbox-exporter.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-consul.sh
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-consul.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-local-unbound.sh
@@ -8,7 +8,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-mastodon.sh
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-mastodon.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # check that redis is active
 echo "Checking for an active redis server"

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-nginx.sh
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-nginx.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-scripts.sh
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-scripts.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+if [ -e /root/.env.cook ]; then
+    . /root/.env.cook
+fi
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+export PATH="/usr/local/bin:$PATH"
+
+SCRIPT=$(readlink -f "$0")
+TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
+
+# shellcheck disable=SC3003,SC2039
+# safe(r) separator for sed
+sep=$'\001'
+
+# make sure we have a /root/bin directory
+mkdir -p /root/bin
+
+# add check-cert.sh script
+< "$TEMPLATEPATH/check-cert.sh.in" \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/check-cert.sh
+
+# set executable permissions
+chmod +x /root/bin/check-cert.sh
+
+# add sendcertalert.sh script
+< "$TEMPLATEPATH/sendcertalert.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertalert.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertalert.sh
+
+# add sendcertexpired.sh script
+< "$TEMPLATEPATH/sendcertexpired.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertexpired.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertexpired.sh
+
+# add check-cert.sh script to /etc/crontab
+echo "# Check SSL certificate every day" >> /etc/crontab
+echo "0	12	*	*	*	root	/root/bin/check-cert.sh /usr/local/etc/ssl/fullchain.cer > /dev/null 2>&1" >> /etc/crontab

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-ssl.sh
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-ssl.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # shellcheck disable=SC2269
 DOMAIN="$DOMAIN"

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/templates/check-cert.sh.in
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/templates/check-cert.sh.in
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Add to /etc/crontab
+#
+# # Check certificate for %%domain%%
+# 0	12	*	*	*	root	/root/bin/check-cert.sh /path/to/certificate.crt > /dev/null 2>&1
+#
+
+# Check if a certificate path is provided
+if [ -z "$1" ]; then
+	echo "Usage: $0 /path/to/certificate.crt"
+	exit 1
+fi
+
+cert_file="$1"
+
+# Check if the certificate file exists
+if [ ! -f "$cert_file" ]; then
+	echo "Error: File '$cert_file' not found."
+	exit 1
+fi
+
+# Extract the expiration date from the certificate
+expiry_date=$(openssl x509 -noout -enddate -in "$cert_file" | awk -F'=' '{print $2}')
+
+# Convert the expiration date to seconds since epoch
+expiry_epoch=$(date -j -f "%b %e %T %Y %Z" "$expiry_date" "+%s")
+
+# Get the current date in seconds since epoch
+current_epoch=$(date -u "+%s")
+
+# Calculate the difference in seconds
+diff_seconds=$((expiry_epoch - current_epoch))
+
+# Convert 10 days to seconds (10 * 24 * 60 * 60)
+ten_days_seconds=$((10 * 24 * 60 * 60))
+
+# Check if the difference is within 10 days
+if [ "$diff_seconds" -le "$ten_days_seconds" ] && [ "$diff_seconds" -gt 0 ]; then
+	echo "The certificate will expire within 10 days."
+	if [ -x /root/bin/sendcertalert.sh ]; then
+		/root/bin/sendcertalert.sh
+	fi
+elif [ "$diff_seconds" -le 0 ]; then
+	echo "The certificate has already expired."
+	if [ -x /root/bin/sendcertexpired.sh ]; then
+		/root/bin/sendcertexpired.sh
+	fi
+else
+	echo "The certificate is valid for more than 10 days."
+fi

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/templates/sendcertalert.sh.in
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/templates/sendcertalert.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpiry",
+      "instance": "%%ip%%:443",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% will expire in 10 days."
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/mastodon-s3/mastodon-s3.d/local/share/cook/templates/sendcertexpired.sh.in
+++ b/mastodon-s3/mastodon-s3.d/local/share/cook/templates/sendcertexpired.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpired",
+      "instance": "%%ip%%:443",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% has expired.",
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/mastodon-s3/mastodon-s3.ini
+++ b/mastodon-s3/mastodon-s3.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mastodon-s3"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.18.3"
+version="0.19.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/matrix-synapse/CHANGELOG.md
+++ b/matrix-synapse/CHANGELOG.md
@@ -1,3 +1,11 @@
+2.13
+
+* Version bump for new base image
+* Quote PATH statements
+* Add certificate expiry with alerts to alertmanager
+
+---
+
 2.12
 
 * Version bump for new base image

--- a/matrix-synapse/matrix-synapse.d/local/bin/cook
+++ b/matrix-synapse/matrix-synapse.d/local/bin/cook
@@ -99,7 +99,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"
@@ -134,11 +134,16 @@ if [ -n "$CONTROLUSER" ]; then
 fi
 
 if [ -n "$NOSSL" ]; then
-    log "Configure nginx-nossl"
-    configure-nginx-nossl.sh
+	log "Configure nginx-nossl"
+	configure-nginx-nossl.sh
 else
-    log "Configure nginx"
-    configure-nginx.sh
+	log "Configure nginx"
+	configure-nginx.sh
+
+	if [ -n "${REMOTELOG}" ]; then
+		log "Configure certificate validity scripts"
+		configure-scripts.sh
+	fi
 fi
 
 log "Start nginx"

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-consul.sh
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-control-user.sh
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-control-user.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # create control user
 pw user add -n control -c 'Control Account' -d /mnt/matrixdata/control -G wheel -m -s /bin/sh

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-matrix.sh
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-matrix.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-nginx-nossl.sh
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-nginx-nossl.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-nginx.sh
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-scripts.sh
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-scripts.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+if [ -e /root/.env.cook ]; then
+    . /root/.env.cook
+fi
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+export PATH="/usr/local/bin:$PATH"
+
+SCRIPT=$(readlink -f "$0")
+TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
+
+# shellcheck disable=SC3003,SC2039
+# safe(r) separator for sed
+sep=$'\001'
+
+# make sure we have a /root/bin directory
+mkdir -p /root/bin
+
+# add check-cert.sh script
+< "$TEMPLATEPATH/check-cert.sh.in" \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/check-cert.sh
+
+# set executable permissions
+chmod +x /root/bin/check-cert.sh
+
+# add sendcertalert.sh script
+< "$TEMPLATEPATH/sendcertalert.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertalert.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertalert.sh
+
+# add sendcertexpired.sh script
+< "$TEMPLATEPATH/sendcertexpired.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertexpired.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertexpired.sh
+
+# add check-cert.sh script to /etc/crontab
+echo "# Check SSL certificate every day" >> /etc/crontab
+echo "0	12	*	*	*	root	/root/bin/check-cert.sh /usr/local/etc/ssl/fullchain.cer > /dev/null 2>&1" >> /etc/crontab

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/templates/check-cert.sh.in
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/templates/check-cert.sh.in
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Add to /etc/crontab
+#
+# # Check certificate for %%domain%%
+# 0	12	*	*	*	root	/root/bin/check-cert.sh /path/to/certificate.crt > /dev/null 2>&1
+#
+
+# Check if a certificate path is provided
+if [ -z "$1" ]; then
+	echo "Usage: $0 /path/to/certificate.crt"
+	exit 1
+fi
+
+cert_file="$1"
+
+# Check if the certificate file exists
+if [ ! -f "$cert_file" ]; then
+	echo "Error: File '$cert_file' not found."
+	exit 1
+fi
+
+# Extract the expiration date from the certificate
+expiry_date=$(openssl x509 -noout -enddate -in "$cert_file" | awk -F'=' '{print $2}')
+
+# Convert the expiration date to seconds since epoch
+expiry_epoch=$(date -j -f "%b %e %T %Y %Z" "$expiry_date" "+%s")
+
+# Get the current date in seconds since epoch
+current_epoch=$(date -u "+%s")
+
+# Calculate the difference in seconds
+diff_seconds=$((expiry_epoch - current_epoch))
+
+# Convert 10 days to seconds (10 * 24 * 60 * 60)
+ten_days_seconds=$((10 * 24 * 60 * 60))
+
+# Check if the difference is within 10 days
+if [ "$diff_seconds" -le "$ten_days_seconds" ] && [ "$diff_seconds" -gt 0 ]; then
+	echo "The certificate will expire within 10 days."
+	if [ -x /root/bin/sendcertalert.sh ]; then
+		/root/bin/sendcertalert.sh
+	fi
+elif [ "$diff_seconds" -le 0 ]; then
+	echo "The certificate has already expired."
+	if [ -x /root/bin/sendcertexpired.sh ]; then
+		/root/bin/sendcertexpired.sh
+	fi
+else
+	echo "The certificate is valid for more than 10 days."
+fi

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/templates/sendcertalert.sh.in
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/templates/sendcertalert.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpiry",
+      "instance": "%%ip%%:443",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% will expire in 10 days."
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/matrix-synapse/matrix-synapse.d/local/share/cook/templates/sendcertexpired.sh.in
+++ b/matrix-synapse/matrix-synapse.d/local/share/cook/templates/sendcertexpired.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpired",
+      "instance": "%%ip%%:443",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% has expired.",
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/matrix-synapse/matrix-synapse.ini
+++ b/matrix-synapse/matrix-synapse.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="matrix-synapse"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.12.2"
+version="2.13.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/netbox/CHANGELOG.md
+++ b/netbox/CHANGELOG.md
@@ -1,3 +1,12 @@
+0.2
+
+* Version bump for new base image
+* Quote PATH statements
+* Add certificate expiry check with alerts to alertmanager
+* Netbox v4.1.11
+
+---
+
 0.1
 
 * Version bump for new base image

--- a/netbox/CHECKLIST.md
+++ b/netbox/CHECKLIST.md
@@ -31,7 +31,7 @@ Changes in python version need updating of package name, or `/usr/local/bin/pyth
 Netbox is currently version 4.1.10.
 
 When netbox version changes in packages, then update `netbox.sh` to correct version after checking compatibility chart at each link
-* `pkg install -y netbox-4.1.10`
+* `pkg install -y netbox-4.1.11`
 * `netbox-inventory==2.2.1` see Compatibility at https://github.com/ArnesSI/netbox-inventory
 * `netbox-bgp==0.14.0` see Compatibility at https://github.com/netbox-community/netbox-bgp
 * `netbox-topology-views==4.1.0` see Versions at https://github.com/netbox-community/netbox-topology-views

--- a/netbox/netbox.d/local/bin/cook
+++ b/netbox/netbox.d/local/bin/cook
@@ -122,7 +122,7 @@ timeout --foreground 10 \
 killall -9 consul || true
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
 	log "Configure and start syslog-ng"
@@ -155,6 +155,11 @@ if [ -n "${PVTCERT}" ]; then
 else
 	log "Configure acme.sh"
 	configure-acme.sh
+
+	if [ -n "${REMOTELOG}" ]; then
+		log "Configure certificate validity scripts"
+		configure-scripts.sh
+	fi
 fi
 
 log "Configure nginx"

--- a/netbox/netbox.d/local/share/cook/bin/check-upgrade.sh
+++ b/netbox/netbox.d/local/share/cook/bin/check-upgrade.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 cd /usr/local/share/netbox || exit 1
 # this upgrades the database schema

--- a/netbox/netbox.d/local/share/cook/bin/configure-acme.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-acme.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/netbox/netbox.d/local/share/cook/bin/configure-consul.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-consul.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/netbox/netbox.d/local/share/cook/bin/configure-gunicorn.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-gunicorn.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # SCRIPT=$(readlink -f "$0")
 # TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/netbox/netbox.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-local-unbound.sh
@@ -8,7 +8,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/netbox/netbox.d/local/share/cook/bin/configure-netbox-rq.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-netbox-rq.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/netbox/netbox.d/local/share/cook/bin/configure-netbox.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-netbox.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # ensure necessary directories are present
 mkdir -p /mnt/netboxdata/media/devicetype-images

--- a/netbox/netbox.d/local/share/cook/bin/configure-nginx.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-nginx.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/netbox/netbox.d/local/share/cook/bin/configure-node-exporter.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-node-exporter.sh
@@ -8,7 +8,7 @@ fi
 set -e
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # add node_exporter user
 if ! id -u "nodeexport" >/dev/null 2>&1; then

--- a/netbox/netbox.d/local/share/cook/bin/configure-scripts.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-scripts.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+if [ -e /root/.env.cook ]; then
+    . /root/.env.cook
+fi
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+export PATH="/usr/local/bin:$PATH"
+
+SCRIPT=$(readlink -f "$0")
+TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
+
+# shellcheck disable=SC3003,SC2039
+# safe(r) separator for sed
+sep=$'\001'
+
+# make sure we have a /root/bin directory
+mkdir -p /root/bin
+
+# add check-cert.sh script
+< "$TEMPLATEPATH/check-cert.sh.in" \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/check-cert.sh
+
+# set executable permissions
+chmod +x /root/bin/check-cert.sh
+
+# add sendcertalert.sh script
+< "$TEMPLATEPATH/sendcertalert.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertalert.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertalert.sh
+
+# add sendcertexpired.sh script
+< "$TEMPLATEPATH/sendcertexpired.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertexpired.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertexpired.sh
+
+# add check-cert.sh script to /etc/crontab
+echo "# Check SSL certificate every day" >> /etc/crontab
+echo "0	12	*	*	*	root	/root/bin/check-cert.sh /usr/local/etc/ssl/fullchain.cer > /dev/null 2>&1" >> /etc/crontab

--- a/netbox/netbox.d/local/share/cook/bin/configure-ssl.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-ssl.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # shellcheck disable=SC2269
 DOMAIN="$DOMAIN"

--- a/netbox/netbox.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/netbox/netbox.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/netbox/netbox.d/local/share/cook/bin/create-superuser.sh
+++ b/netbox/netbox.d/local/share/cook/bin/create-superuser.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # docker-compose version uses different approach which may be more useful
 # to avoid error condition in output. Not in use until scripted token 

--- a/netbox/netbox.d/local/share/cook/templates/check-cert.sh.in
+++ b/netbox/netbox.d/local/share/cook/templates/check-cert.sh.in
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Add to /etc/crontab
+#
+# # Check certificate for %%domain%%
+# 0	12	*	*	*	root	/root/bin/check-cert.sh /path/to/certificate.crt > /dev/null 2>&1
+#
+
+# Check if a certificate path is provided
+if [ -z "$1" ]; then
+	echo "Usage: $0 /path/to/certificate.crt"
+	exit 1
+fi
+
+cert_file="$1"
+
+# Check if the certificate file exists
+if [ ! -f "$cert_file" ]; then
+	echo "Error: File '$cert_file' not found."
+	exit 1
+fi
+
+# Extract the expiration date from the certificate
+expiry_date=$(openssl x509 -noout -enddate -in "$cert_file" | awk -F'=' '{print $2}')
+
+# Convert the expiration date to seconds since epoch
+expiry_epoch=$(date -j -f "%b %e %T %Y %Z" "$expiry_date" "+%s")
+
+# Get the current date in seconds since epoch
+current_epoch=$(date -u "+%s")
+
+# Calculate the difference in seconds
+diff_seconds=$((expiry_epoch - current_epoch))
+
+# Convert 10 days to seconds (10 * 24 * 60 * 60)
+ten_days_seconds=$((10 * 24 * 60 * 60))
+
+# Check if the difference is within 10 days
+if [ "$diff_seconds" -le "$ten_days_seconds" ] && [ "$diff_seconds" -gt 0 ]; then
+	echo "The certificate will expire within 10 days."
+	if [ -x /root/bin/sendcertalert.sh ]; then
+		/root/bin/sendcertalert.sh
+	fi
+elif [ "$diff_seconds" -le 0 ]; then
+	echo "The certificate has already expired."
+	if [ -x /root/bin/sendcertexpired.sh ]; then
+		/root/bin/sendcertexpired.sh
+	fi
+else
+	echo "The certificate is valid for more than 10 days."
+fi

--- a/netbox/netbox.d/local/share/cook/templates/sendcertalert.sh.in
+++ b/netbox/netbox.d/local/share/cook/templates/sendcertalert.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpiry",
+      "instance": "%%ip%%:443",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% will expire in 10 days."
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/netbox/netbox.d/local/share/cook/templates/sendcertexpired.sh.in
+++ b/netbox/netbox.d/local/share/cook/templates/sendcertexpired.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpired",
+      "instance": "%%ip%%:443",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% has expired.",
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/netbox/netbox.ini
+++ b/netbox/netbox.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="netbox"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.1.3"
+version="0.2.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/netbox/netbox.sh
+++ b/netbox/netbox.sh
@@ -152,8 +152,8 @@ pkg install -y redis
 step "Install package postgresql16-client"
 pkg install -y postgresql16-client
 
-step "Install package netbox-4.1.10"
-pkg install -y netbox-4.1.10
+step "Install package netbox-4.1.11"
+pkg install -y netbox-4.1.11
 
 step "Install package py311-netbox-secrets"
 pkg install -y py311-netbox-secrets

--- a/nextcloud-nginx-nomad/CHANGELOG.md
+++ b/nextcloud-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.116
+
+* Version bump for new image with pkg 2
+* Quote PATH statements
+
+---
+
 0.113
 
 * Version bump for new quarterlies

--- a/nextcloud-nginx-nomad/README.md
+++ b/nextcloud-nginx-nomad/README.md
@@ -246,7 +246,7 @@ job "nextcloud" {
       config {
         image = "https://potluck.honeyguide.net/nextcloud-nginx-nomad"
         pot = "nextcloud-nginx-nomad-amd64-14_2"
-        tag = "0.115"
+        tag = "0.116"
         command = "/usr/local/bin/cook"
         args = ["-d","/mnt/filestore","-s","host:ip"]
         copy = [

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/bin/cook
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/bin/cook
@@ -92,7 +92,7 @@ done
 ## Provision image
 ########################################################################
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 log "stop nginx service, kill nginx if around"
 service nginx onestop || true

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-caddy.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-caddy.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-cron.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-cron.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # setup nextcloud cronjob
 echo "*/15 * * * *  www  /usr/local/bin/php -f /usr/local/www/nextcloud/cron.php" >> /etc/crontab

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-custom.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-custom.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 #SCRIPT=$(readlink -f "$0")
 #TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-nextcloud.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-nextcloud.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-nginx.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-php.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/configure-php.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/install-nextcloud-github.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/install-nextcloud-github.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # If we do not find a Nextcloud installation, we install it. If we do find something though,
 # we do not install/overwrite anything as we assume that updates/modifications are happening

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/install-nextcloud.sh
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.d/local/share/cook/bin/install-nextcloud.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # If we do not find a Nextcloud installation, we install it. If we do find something though,
 # we do not install/overwrite anything as we assume that updates/modifications are happening

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.115"
+version="0.116"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nextcloud-spreed-signalling/CHANGELOG.md
+++ b/nextcloud-spreed-signalling/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.6
+
+* Version bump for new base image
+* Quote PATH statements
+* Add certificate expiry check with alerts to alertmanager
+
+---
+
 0.5
 
 * Version bump for new base image

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/bin/cook
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/bin/cook
@@ -99,7 +99,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"
@@ -144,6 +144,11 @@ if [ -n "${PVTCERT}" ]; then
 else
 	log "Configure SSL certificate with acme.sh"
 	configure-acme.sh
+
+	if [ -n "${REMOTELOG}" ]; then
+		log "Configure certificate validity scripts"
+		configure-scripts.sh
+	fi
 fi
 
 log "Configure nginx server"

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-acme.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-acme.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-consul.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-janus.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-janus.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-nats.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-nats.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-nginx.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-rabbitmq.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-rabbitmq.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-scripts.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-scripts.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+if [ -e /root/.env.cook ]; then
+    . /root/.env.cook
+fi
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+export PATH="/usr/local/bin:$PATH"
+
+SCRIPT=$(readlink -f "$0")
+TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
+
+# shellcheck disable=SC3003,SC2039
+# safe(r) separator for sed
+sep=$'\001'
+
+# make sure we have a /root/bin directory
+mkdir -p /root/bin
+
+# add check-cert.sh script
+< "$TEMPLATEPATH/check-cert.sh.in" \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/check-cert.sh
+
+# set executable permissions
+chmod +x /root/bin/check-cert.sh
+
+# add sendcertalert.sh script
+< "$TEMPLATEPATH/sendcertalert.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertalert.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertalert.sh
+
+# add sendcertexpired.sh script
+< "$TEMPLATEPATH/sendcertexpired.sh.in" \
+  sed "s${sep}%%remotelogip%%${sep}$REMOTELOG${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  > /root/bin/sendcertexpired.sh
+
+# set executable permissions
+chmod +x /root/bin/sendcertexpired.sh
+
+# add check-cert.sh script to /etc/crontab
+echo "# Check SSL certificate every day" >> /etc/crontab
+echo "0	12	*	*	*	root	/root/bin/check-cert.sh /usr/local/etc/ssl/fullchain.cer > /dev/null 2>&1" >> /etc/crontab

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-spreed.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-spreed.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-ssl.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-ssl.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 DOMAIN="$DOMAIN"
 IP="$IP"

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-turnserver.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-turnserver.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/check-cert.sh.in
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/check-cert.sh.in
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Add to /etc/crontab
+#
+# # Check certificate for %%domain%%
+# 0	12	*	*	*	root	/root/bin/check-cert.sh /path/to/certificate.crt > /dev/null 2>&1
+#
+
+# Check if a certificate path is provided
+if [ -z "$1" ]; then
+	echo "Usage: $0 /path/to/certificate.crt"
+	exit 1
+fi
+
+cert_file="$1"
+
+# Check if the certificate file exists
+if [ ! -f "$cert_file" ]; then
+	echo "Error: File '$cert_file' not found."
+	exit 1
+fi
+
+# Extract the expiration date from the certificate
+expiry_date=$(openssl x509 -noout -enddate -in "$cert_file" | awk -F'=' '{print $2}')
+
+# Convert the expiration date to seconds since epoch
+expiry_epoch=$(date -j -f "%b %e %T %Y %Z" "$expiry_date" "+%s")
+
+# Get the current date in seconds since epoch
+current_epoch=$(date -u "+%s")
+
+# Calculate the difference in seconds
+diff_seconds=$((expiry_epoch - current_epoch))
+
+# Convert 10 days to seconds (10 * 24 * 60 * 60)
+ten_days_seconds=$((10 * 24 * 60 * 60))
+
+# Check if the difference is within 10 days
+if [ "$diff_seconds" -le "$ten_days_seconds" ] && [ "$diff_seconds" -gt 0 ]; then
+	echo "The certificate will expire within 10 days."
+	if [ -x /root/bin/sendcertalert.sh ]; then
+		/root/bin/sendcertalert.sh
+	fi
+elif [ "$diff_seconds" -le 0 ]; then
+	echo "The certificate has already expired."
+	if [ -x /root/bin/sendcertexpired.sh ]; then
+		/root/bin/sendcertexpired.sh
+	fi
+else
+	echo "The certificate is valid for more than 10 days."
+fi

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/sendcertalert.sh.in
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/sendcertalert.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpiry",
+      "instance": "%%ip%%:443",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% will expire in 10 days."
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/sendcertexpired.sh.in
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/sendcertexpired.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+URL="http://%%remotelogip%%:9093/api/v2/alerts"
+
+/usr/local/bin/curl -si -X POST -H "Content-Type: application/json" "$URL" -d '
+[
+  {
+    "labels": {
+      "alertname": "CertificateExpired",
+      "instance": "%%ip%%:443",
+      "job": "node",
+      "severity": "critical"
+    },
+    "annotations": {
+      "summary": "Certificate for %%domain%% has expired.",
+    },
+    "generatorURL": "http://%%remotelogip%%:9090/graph"
+  }
+]
+'

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-spreed-signalling"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.5.2"
+version="0.6.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-nomad-alt/CHANGELOG.md
+++ b/nginx-nomad-alt/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.22
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.21
 
 * Version bump for new base image

--- a/nginx-nomad-alt/README.md
+++ b/nginx-nomad-alt/README.md
@@ -63,7 +63,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-nomad-alt"
         pot = "nginx-nomad-alt-amd64-14_2"
-        tag = "0.21.2"
+        tag = "0.22.1"
         command = "/usr/local/bin/cook"
         args = ["-s","servername"]
         mount = [

--- a/nginx-nomad-alt/nginx-nomad-alt.d/local/bin/cook
+++ b/nginx-nomad-alt/nginx-nomad-alt.d/local/bin/cook
@@ -80,7 +80,7 @@ done
 ## Provision image
 ########################################################################
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 log "stop nginx service, kill nginx if around"
 service nginx onestop || true

--- a/nginx-nomad-alt/nginx-nomad-alt.d/local/share/cook/bin/configure-nginx.sh
+++ b/nginx-nomad-alt/nginx-nomad-alt.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-nomad-alt/nginx-nomad-alt.d/local/share/cook/bin/configure-php.sh
+++ b/nginx-nomad-alt/nginx-nomad-alt.d/local/share/cook/bin/configure-php.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-nomad-alt/nginx-nomad-alt.ini
+++ b/nginx-nomad-alt/nginx-nomad-alt.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-nomad-alt"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.21.2"
+version="0.22.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-rsync-ssh/CHANGELOG.md
+++ b/nginx-rsync-ssh/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.24
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.23
 
 * Version bump for new base image

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/bin/cook
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/bin/cook
@@ -82,7 +82,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${SETUPSCRIPT}" ]; then
     log "run pre setup script"

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-authkeys.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-authkeys.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 if [ -f /root/authorized_keys_in ]; then
     echo "Adding imported keys to /root/.ssh/authorized_keys"

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-consul.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-goaccess.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-goaccess.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-nginx.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # if nginx.conf copied in
 if [ -f /root/nginx.conf ]; then

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-root-ssh.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-root-ssh.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # create root ssh keys
 mkdir -p /root/.ssh

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-rsync.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-rsync.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # copy over rsyncd.conf if copied in
 if [ -f /root/rsyncd.conf ]; then

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-sshd.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-sshd.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # if sshd_config has been copied in correctly
 # replace /etc/ssh/sshd_config

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/run-postsetup.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/run-postsetup.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # if post setup script copied in, make executable and run
 if [ -f /root/postsetup.sh ]; then

--- a/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/run-setupscript.sh
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.d/local/share/cook/bin/run-setupscript.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # if setup script has been copied in, run it
 if [ -f /root/setup.sh ]; then

--- a/nginx-rsync-ssh/nginx-rsync-ssh.ini
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-rsync-ssh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.23.2"
+version="0.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-s3-nomad/CHANGELOG.md
+++ b/nginx-s3-nomad/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.24
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.23
 
 * Version bump for new base image

--- a/nginx-s3-nomad/README.md
+++ b/nginx-s3-nomad/README.md
@@ -96,7 +96,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
         pot = "nginx-s3-nomad-amd64-14_2"
-        tag = "0.23.3"
+        tag = "0.24.1"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-x","bucketname","-s","yes"]
         port_map = {
@@ -150,7 +150,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
         pot = "nginx-s3-nomad-amd64-14_2"
-        tag = "0.23.3"
+        tag = "0.24.1"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-c","10.0.0.4","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-nomad/nginx-s3-nomad.d/local/bin/cook
+++ b/nginx-s3-nomad/nginx-s3-nomad.d/local/bin/cook
@@ -92,7 +92,7 @@ done
 ## Provision image
 ########################################################################
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 log "stop nginx service, kill nginx if around"
 service nginx onestop || true

--- a/nginx-s3-nomad/nginx-s3-nomad.d/local/share/cook/bin/configure-nginx.sh
+++ b/nginx-s3-nomad/nginx-s3-nomad.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-s3-nomad/nginx-s3-nomad.d/local/share/cook/bin/configure-nginx2.sh
+++ b/nginx-s3-nomad/nginx-s3-nomad.d/local/share/cook/bin/configure-nginx2.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-s3-nomad/nginx-s3-nomad.d/local/share/cook/bin/configure-nginx3.sh
+++ b/nginx-s3-nomad/nginx-s3-nomad.d/local/share/cook/bin/configure-nginx3.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-s3-nomad/nginx-s3-nomad.d/local/share/cook/bin/configure-selfsigned.sh
+++ b/nginx-s3-nomad/nginx-s3-nomad.d/local/share/cook/bin/configure-selfsigned.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # configure self-signed certificates by adding minio certicate to local CA store
 echo "" |/usr/bin/openssl s_client -showcerts -noservername -connect "$SERVERONE:9000" |/usr/bin/openssl x509 -outform PEM > /tmp/cert.pem

--- a/nginx-s3-nomad/nginx-s3-nomad.ini
+++ b/nginx-s3-nomad/nginx-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.23.3"
+version="0.24.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-s3-ssl-nomad/CHANGELOG.md
+++ b/nginx-s3-ssl-nomad/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.13
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.12
 
 * Version bump for new base image

--- a/nginx-s3-ssl-nomad/README.md
+++ b/nginx-s3-ssl-nomad/README.md
@@ -98,7 +98,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.12.3"
+        tag = "0.13.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -152,7 +152,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.12.3"
+        tag = "0.13.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -206,7 +206,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.12.3"
+        tag = "0.13.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-g","10.0.0.4:9000","-h","10.0.0.5:9000","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/bin/cook
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/bin/cook
@@ -98,7 +98,7 @@ done
 ## Provision image
 ########################################################################
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 log "stop nginx service, kill nginx if around"
 service nginx onestop || true

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-nginx.sh
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-nginx2.sh
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-nginx2.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-nginx4.sh
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-nginx4.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-selfsigned.sh
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-selfsigned.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # configure self-signed certificates by adding minio certicate to local CA store
 echo "" |/usr/bin/openssl s_client -showcerts -noservername -connect "$SERVERONE" |/usr/bin/openssl x509 -outform PEM > /tmp/cert.pem

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-ssl.sh
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.d/local/share/cook/bin/configure-ssl.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 DOMAIN="$DOMAIN"
 

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.12.3"
+version="0.13.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-varnish-ssl-nomad/CHANGELOG.md
+++ b/nginx-varnish-ssl-nomad/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.4
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.3
 
 * Version bump for new base image

--- a/nginx-varnish-ssl-nomad/README.md
+++ b/nginx-varnish-ssl-nomad/README.md
@@ -69,7 +69,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-varnish-ssl-nomad"
         pot = "nginx-varnish-ssl-nomad-amd64-14_2"
-        tag = "0.3.3"
+        tag = "0.4.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-s","10.0.0.2:8080","-b","bucketname"]
         port_map = {

--- a/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.d/local/bin/cook
+++ b/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.d/local/bin/cook
@@ -88,7 +88,7 @@ done
 ########################################################################
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 log "stop nginx service, kill nginx if around"
 service nginx onestop || true

--- a/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.d/local/share/cook/bin/configure-nginx.sh
+++ b/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.d/local/share/cook/bin/configure-nginx.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.d/local/share/cook/bin/configure-ssl.sh
+++ b/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.d/local/share/cook/bin/configure-ssl.sh
@@ -10,7 +10,7 @@ set -e
 set -o pipefail
 
 # shellcheck disable=SC2086
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # shellcheck disable=SC2269
 DOMAIN="$DOMAIN"

--- a/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
+++ b/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-varnish-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.3.3"
+version="0.4.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nomad-server/CHANGELOG.md
+++ b/nomad-server/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.25
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 3.24
 
 * Version bump for new base image

--- a/nomad-server/nomad-server.d/local/bin/cook
+++ b/nomad-server/nomad-server.d/local/bin/cook
@@ -122,7 +122,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/nomad-server/nomad-server.d/local/share/cook/bin/configure-consul.sh
+++ b/nomad-server/nomad-server.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nomad-server/nomad-server.d/local/share/cook/bin/configure-jobs.sh
+++ b/nomad-server/nomad-server.d/local/share/cook/bin/configure-jobs.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo "Importing job files from /root/nomadjobs"
 cd /root/nomadjobs/

--- a/nomad-server/nomad-server.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/nomad-server/nomad-server.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/nomad-server/nomad-server.d/local/share/cook/bin/configure-nomad.sh
+++ b/nomad-server/nomad-server.d/local/share/cook/bin/configure-nomad.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # fix /var/tmp/nomad issue
 if [ -d /var/tmp/nomad ]; then

--- a/nomad-server/nomad-server.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/nomad-server/nomad-server.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/nomad-server/nomad-server.ini
+++ b/nomad-server/nomad-server.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nomad-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="3.24.1"
+version="3.25.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/openldap/CHANGELOG.md
+++ b/openldap/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.26
+
+* Version bump for new base image
+
+---
+
 1.25
 
 * Version bump for new base image

--- a/openldap/openldap.ini
+++ b/openldap/openldap.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="openldap"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.25.4"
+version="1.26.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/opensearch/CHANGELOG.md
+++ b/opensearch/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.10
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.9
 
 * Version bump for new base image

--- a/opensearch/opensearch.d/local/bin/cook
+++ b/opensearch/opensearch.d/local/bin/cook
@@ -91,7 +91,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/opensearch/opensearch.d/local/share/cook/bin/configure-consul.sh
+++ b/opensearch/opensearch.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/opensearch/opensearch.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/opensearch/opensearch.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/opensearch/opensearch.d/local/share/cook/bin/configure-opensearch.sh
+++ b/opensearch/opensearch.d/local/share/cook/bin/configure-opensearch.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/opensearch/opensearch.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/opensearch/opensearch.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/opensearch/opensearch.ini
+++ b/opensearch/opensearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="opensearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.9.2"
+version="0.10.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/postfix-backupmx-nomad/CHANGELOG.md
+++ b/postfix-backupmx-nomad/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.21
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 1.20
 
 * Version bump for new base image

--- a/postfix-backupmx-nomad/README.md
+++ b/postfix-backupmx-nomad/README.md
@@ -54,7 +54,7 @@ job "backupmx" {
       config {
         image = "https://potluck.honeyguide.net/postfix-backupmx-nomad"
         pot = "postfix-backupmx-nomad-amd64-14_2"
-        tag = "1.20.1"
+        tag = "1.21.1"
         command = "/usr/local/bin/cook"
         args = ["-n","10.10.10.10/32","-d","'example1.com, example2.com, example.de'","-b","'mx2.example1.com ESMTP \\$mail_name'","-h","mx2.example1.com"]
         mount = [
@@ -117,7 +117,7 @@ job "backupmx" {
        config {
         image = "https://potluck.honeyguide.net/postfix-backupmx-nomad"
         pot = "postfix-backupmx-nomad-amd64-14_2"
-        tag = "1.20.1"
+        tag = "1.21.1"
         command = "/usr/local/bin/cook"
         args = [""]
 

--- a/postfix-backupmx-nomad/postfix-backupmx-nomad.d/local/bin/cook
+++ b/postfix-backupmx-nomad/postfix-backupmx-nomad.d/local/bin/cook
@@ -92,7 +92,7 @@ done
 ## Provision image
 ########################################################################
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 log "Configure postfix"
 configure-postfix.sh

--- a/postfix-backupmx-nomad/postfix-backupmx-nomad.d/local/share/cook/bin/configure-postfix.sh
+++ b/postfix-backupmx-nomad/postfix-backupmx-nomad.d/local/share/cook/bin/configure-postfix.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/postfix-backupmx-nomad/postfix-backupmx-nomad.ini
+++ b/postfix-backupmx-nomad/postfix-backupmx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postfix-backupmx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.20.1"
+version="1.21.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/postgres-single/CHANGELOG.md
+++ b/postgres-single/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.15
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.14
 
 * Version bump for new base image

--- a/postgres-single/postgres-single.d/local/bin/cook
+++ b/postgres-single/postgres-single.d/local/bin/cook
@@ -82,7 +82,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/postgres-single/postgres-single.d/local/share/cook/bin/configure-backups.sh
+++ b/postgres-single/postgres-single.d/local/share/cook/bin/configure-backups.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/postgres-single/postgres-single.d/local/share/cook/bin/configure-consul.sh
+++ b/postgres-single/postgres-single.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/postgres-single/postgres-single.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/postgres-single/postgres-single.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/postgres-single/postgres-single.d/local/share/cook/bin/configure-postgres-exporter.sh
+++ b/postgres-single/postgres-single.d/local/share/cook/bin/configure-postgres-exporter.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 #SCRIPT=$(readlink -f "$0")
 #TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/postgres-single/postgres-single.d/local/share/cook/bin/configure-postgres.sh
+++ b/postgres-single/postgres-single.d/local/share/cook/bin/configure-postgres.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/postgres-single/postgres-single.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/postgres-single/postgres-single.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/postgres-single/postgres-single.d/local/share/cook/bin/postgres-post-init.sh
+++ b/postgres-single/postgres-single.d/local/share/cook/bin/postgres-post-init.sh
@@ -5,7 +5,7 @@ set -e
 set -o pipefail
 
 # we need a path set else sudo not found
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # make sure we're not in /root else this error occurs:
 #

--- a/postgres-single/postgres-single.d/local/share/cook/bin/run-custom.sh
+++ b/postgres-single/postgres-single.d/local/share/cook/bin/run-custom.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # this will run an imported script copied into /root/customscript.sh
 # if the file exists.

--- a/postgres-single/postgres-single.ini
+++ b/postgres-single/postgres-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postgres-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.14.2"
+version="0.15.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/rbldnsd/CHANGELOG.md
+++ b/rbldnsd/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Version bump for new base image
 * Add quotes to PATH to fix shellcheck complaint
 * Add scripts to check certificate validity and send alerts via alertmanager
+* Include note in alerts that this image automatically renews certificates
 
 ---
 

--- a/rbldnsd/rbldnsd.d/local/share/cook/templates/sendcertalert.sh.in
+++ b/rbldnsd/rbldnsd.d/local/share/cook/templates/sendcertalert.sh.in
@@ -12,7 +12,7 @@ URL="http://%%remotelogip%%:9093/api/v2/alerts"
       "severity": "critical"
     },
     "annotations": {
-      "summary": "Certificate for %%domain%% will expire in 10 days"
+      "summary": "Certificate for bl.%%domain%% will expire in 10 days. This host automatically renews certificates. No user action is required."
     },
     "generatorURL": "http://%%remotelogip%%:9090/graph"
   }

--- a/rbldnsd/rbldnsd.d/local/share/cook/templates/sendcertexpired.sh.in
+++ b/rbldnsd/rbldnsd.d/local/share/cook/templates/sendcertexpired.sh.in
@@ -12,7 +12,7 @@ URL="http://%%remotelogip%%:9093/api/v2/alerts"
       "severity": "critical"
     },
     "annotations": {
-      "summary": "Certificate for %%domain%% has expired"
+      "summary": "Certificate for bl.%%domain%% has expired. This should not happen on this host due to automatic renewal.",
     },
     "generatorURL": "http://%%remotelogip%%:9090/graph"
   }

--- a/rbldnsd/rbldnsd.ini
+++ b/rbldnsd/rbldnsd.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="rbldnsd"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.23.1"
+version="0.23.2"
 origin="freebsd"
 runs_in_nomad="false"

--- a/redis-single/CHANGELOG.md
+++ b/redis-single/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.15
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.14
 
 * Version bump for new base image

--- a/redis-single/redis-single.d/local/bin/cook
+++ b/redis-single/redis-single.d/local/bin/cook
@@ -85,7 +85,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/redis-single/redis-single.d/local/share/cook/bin/configure-consul.sh
+++ b/redis-single/redis-single.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/redis-single/redis-single.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/redis-single/redis-single.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/redis-single/redis-single.d/local/share/cook/bin/configure-redis.sh
+++ b/redis-single/redis-single.d/local/share/cook/bin/configure-redis.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # check we have /mnt/redisdata
 mkdir -p /mnt/redisdata

--- a/redis-single/redis-single.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/redis-single/redis-single.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/redis-single/redis-single.ini
+++ b/redis-single/redis-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="redis-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.14.2"
+version="0.15.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/saltstack/CHANGELOG.md
+++ b/saltstack/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.23
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.22
 
 * Version bump for new base image

--- a/saltstack/saltstack.d/local/bin/cook
+++ b/saltstack/saltstack.d/local/bin/cook
@@ -89,7 +89,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/saltstack/saltstack.d/local/share/cook/bin/configure-consul.sh
+++ b/saltstack/saltstack.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/saltstack/saltstack.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/saltstack/saltstack.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/saltstack/saltstack.d/local/share/cook/bin/configure-salt.sh
+++ b/saltstack/saltstack.d/local/share/cook/bin/configure-salt.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/saltstack/saltstack.d/local/share/cook/bin/configure-sshd.sh
+++ b/saltstack/saltstack.d/local/share/cook/bin/configure-sshd.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/saltstack/saltstack.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/saltstack/saltstack.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/saltstack/saltstack.ini
+++ b/saltstack/saltstack.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="saltstack"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.22.1"
+version="0.23.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traefik-consul/CHANGELOG.md
+++ b/traefik-consul/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.27
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 1.26
 
 * Version bump for new base image

--- a/traefik-consul/traefik-consul.d/local/bin/cook
+++ b/traefik-consul/traefik-consul.d/local/bin/cook
@@ -91,7 +91,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-consul.sh
+++ b/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-openssl.sh
+++ b/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-openssl.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # create local ssl directory
 mkdir -p /usr/local/etc/ssl/

--- a/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-traefik.sh
+++ b/traefik-consul/traefik-consul.d/local/share/cook/bin/configure-traefik.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/traefik-consul/traefik-consul.ini
+++ b/traefik-consul/traefik-consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traefik-consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.26.1"
+version="1.27.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traumadrill/CHANGELOG.md
+++ b/traumadrill/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.25
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 1.24
 
 * Version bump for new base image

--- a/traumadrill/traumadrill.d/local/bin/cook
+++ b/traumadrill/traumadrill.d/local/bin/cook
@@ -85,7 +85,7 @@ killall -9 consul || true
 # setup directories for persistent storage (not in use currently)
 mkdir -p /mnt/stress
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/traumadrill/traumadrill.d/local/share/cook/bin/configure-consul.sh
+++ b/traumadrill/traumadrill.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/traumadrill/traumadrill.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/traumadrill/traumadrill.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/traumadrill/traumadrill.d/local/share/cook/bin/configure-nginx.sh
+++ b/traumadrill/traumadrill.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/traumadrill/traumadrill.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/traumadrill/traumadrill.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/traumadrill/traumadrill.ini
+++ b/traumadrill/traumadrill.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traumadrill"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.24.3"
+version="1.25.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/wordpress-nginx-nomad/CHANGELOG.md
+++ b/wordpress-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,10 @@
+2.21
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 2.20
 
 * Version bump for new base image

--- a/wordpress-nginx-nomad/README.md
+++ b/wordpress-nginx-nomad/README.md
@@ -59,7 +59,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/wordpress-nginx-nomad"
         pot = "wordpress-nginx-nomad-amd64-14_2"
-        tag = "2.20.3"
+        tag = "2.21.1"
         command = "/usr/local/bin/cook"
         args = [""]
         mount = [

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/bin/cook
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/bin/cook
@@ -83,7 +83,7 @@ done
 ## Provision image
 ########################################################################
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 log "stop nginx service, kill nginx if around"
 service nginx onestop || true

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/share/cook/bin/configure-cron.sh
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/share/cook/bin/configure-cron.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # setup cronjob
 #echo "*/15 * * * *  www  /usr/local/bin/php -f /usr/local/www/wordpress/cron.php" >> /etc/crontab

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/share/cook/bin/configure-nginx.sh
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/share/cook/bin/configure-php.sh
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/share/cook/bin/configure-php.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/share/cook/bin/install-wordpress.sh
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.d/local/share/cook/bin/install-wordpress.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 # install wordpress
 pkg install -y wordpress || true

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="wordpress-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.20.3"
+version="2.21.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/zincsearch/CHANGELOG.md
+++ b/zincsearch/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.7
+
+* Version bump for new base image
+* Quote PATH statements
+
+---
+
 0.6
 
 * Version bump for new base image

--- a/zincsearch/zincsearch.d/local/bin/cook
+++ b/zincsearch/zincsearch.d/local/bin/cook
@@ -95,7 +95,7 @@ timeout --foreground 10 \
   service consul onestop || service consul onestop || true
 killall -9 consul || true
 
-export PATH=/usr/local/share/cook/bin:$PATH
+export PATH="/usr/local/share/cook/bin:$PATH"
 
 if [ -n "${REMOTELOG}" ]; then
     log "Configure and start syslog-ng"

--- a/zincsearch/zincsearch.d/local/share/cook/bin/configure-consul.sh
+++ b/zincsearch/zincsearch.d/local/share/cook/bin/configure-consul.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/zincsearch/zincsearch.d/local/share/cook/bin/configure-local-unbound.sh
+++ b/zincsearch/zincsearch.d/local/share/cook/bin/configure-local-unbound.sh
@@ -7,7 +7,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 echo 'server:
   do-not-query-localhost: no

--- a/zincsearch/zincsearch.d/local/share/cook/bin/configure-nginx.sh
+++ b/zincsearch/zincsearch.d/local/share/cook/bin/configure-nginx.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/zincsearch/zincsearch.d/local/share/cook/bin/configure-syslog-ng.sh
+++ b/zincsearch/zincsearch.d/local/share/cook/bin/configure-syslog-ng.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 SCRIPT=$(readlink -f "$0")
 TEMPLATEPATH=$(dirname "$SCRIPT")/../templates

--- a/zincsearch/zincsearch.d/local/share/cook/bin/configure-zincsearch.sh
+++ b/zincsearch/zincsearch.d/local/share/cook/bin/configure-zincsearch.sh
@@ -9,7 +9,7 @@ set -e
 # shellcheck disable=SC3040
 set -o pipefail
 
-export PATH=/usr/local/bin:$PATH
+export PATH="/usr/local/bin:$PATH"
 
 if ! id -u "zincsearch" >/dev/null 2>&1; then
   /usr/sbin/pw useradd -n zincsearch -c 'zincsearch user' -m -s /usr/sbin/nologin -h -

--- a/zincsearch/zincsearch.ini
+++ b/zincsearch/zincsearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="zincsearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.6.2"
+version="0.7.1"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
adminer: version bump for new base image
backuppc-nomad: version bump for new base image
backuppc-nomad: quote path lines
beast-of-argh: version bump for new base image
caddy-s3-nomad: version bump for new base image
caddy-s3-nomad: Add certificate expiry scripts for alertmanager notices
consul: version bump for new base image
dmarc-report: version bump for new base image, quote PATH statements
git-nomad: version bump for new base image, quote PATH statements
haproxy-minio: version bump for new base image, Quote PATH statements, Fix error in CHECKLIST.md
haproxy-sql: version bump for new base image, Quote PATH statements
hugo-nginx: version bump for new base image, Quote PATH statements
hugo-nginx-alt: version bump for new base image, Quote PATH statements
jenkins: version bump for new base image, Quote PATH statements
mailhub-potluck: version bump for new base image, add certificate expiry scripts for alertmanager
mariadb: version bump for new base image, Quote PATH statements
mariadb-galera: version bump for new base image, Quote PATH statements
mastodon-s3: version bump for new image with pkg 2, add certificate expiry checks to alertmanager, quote PATH statements
matrix-synapse: version bump for new base image, quote PATH statements, add certificate expiry with alerts to alertmanager
netbox: version bump for new base image, quote PATH statements, add certificate expiry check with alerts to alertmanager, Netbox v4.1.11
nextcloud-nginx-nomad: version bump for new image with pkg 2, quote PATH statements
nextcloud-spreed-signalling: version bump for new base image, quote PATH statements, add certificate expiry check with alerts to alertmanager
nginx-nomad-alt: version bump for new base image, quote PATH statements
nginx-rsync-ssh: version bump for new base image, quote PATH statements
nginx-s3-nomad: version bump for new base image, quote PATH statements
nginx-s3-ssl-nomad: version bump for new base image, quote PATH statements
nginx-varnish-ssl-nomad: version bump for new base image, quote PATH statements
nomad-server: version bump for new base image, quote PATH statements
openldap: version bump for new base image
opensearch: version bump for new base image, quote PATH statements
postfix-backupmx-nomad: version bump for new base image, quote PATH statements
postgres-single: version bump for new base image, quote PATH statements
redis-single: version bump for new base image, quote PATH statements
rbldnsd: Include note in alerts that this image automatically renews certificates
saltstack: version bump for new base image, quote PATH statements
traefik-consul: version bump for new base image, quote PATH statements
traumadrill: version bump for new base image, quote PATH statements
wordpress-nginx-nomad: version bump for new base image, quote PATH statements
zincsearch: version bump for new base image, quote PATH statements