### PR TITLE
Usagefixes1

### DIFF
--- a/remoter/CHANGELOG.md
+++ b/remoter/CHANGELOG.md
@@ -7,3 +7,4 @@
 * Store only 3 days of postgresql backups
 * Create logs directory and update mirror scripts to log here
 * Fix consul labels and set IP parameters, set 127.0.0.1 only for consul client_addr
+* Don't overwrite existing authorized_keys file if exists

--- a/remoter/remoter.d/local/share/cook/bin/configure-user.sh
+++ b/remoter/remoter.d/local/share/cook/bin/configure-user.sh
@@ -24,11 +24,20 @@ sep=$'\001'
 # configure ssh user ssh keys
 mkdir -p "/mnt/home/$SSHUSER/.ssh"
 
-# set permissions
-cat "/root/authorized_keys_in" > "/mnt/home/$SSHUSER/.ssh/authorized_keys"
-chown -R "$SSHUSER:$SSHUSER" "/mnt/home/$SSHUSER/.ssh"
-chmod 600 "/mnt/home/$SSHUSER/.ssh/authorized_keys"
-chmod 700 "/mnt/home/$SSHUSER/.ssh"
+# set authorized_keys if not exist
+if [ -f "/root/authorized_keys_in" ]; then
+	if [ -f "/mnt/home/$SSHUSER/.ssh/authorized_keys" ]; then
+		echo "authorized_keys already exists at the destination. Skipping copy."
+	else
+		cat "/root/authorized_keys_in" > "/mnt/home/$SSHUSER/.ssh/authorized_keys"
+		# set permissions
+		chown -R "$SSHUSER:$SSHUSER" "/mnt/home/$SSHUSER/.ssh"
+		chmod 600 "/mnt/home/$SSHUSER/.ssh/authorized_keys"
+		chmod 700 "/mnt/home/$SSHUSER/.ssh"
+	fi
+else
+	exit_error "No /root/authorized_keys_in file found"
+fi
 
 # create minio client directory
 mkdir -p "/mnt/home/$SSHUSER/.minio-client"

--- a/remoter/remoter.ini
+++ b/remoter/remoter.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="remoter"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.0.5"
+version="0.0.6"
 origin="freebsd"
 runs_in_nomad="false"

--- a/unison-ssh/CHANGELOG.md
+++ b/unison-ssh/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 * First bash at unison-ssh jail
 * Fix consul labels and set IP parameters
+* Don't overwrite /mnt/home/unison/.ssh/authorized_keys if it exists
 
 

--- a/unison-ssh/unison-ssh.d/local/share/cook/bin/configure-unison.sh
+++ b/unison-ssh/unison-ssh.d/local/share/cook/bin/configure-unison.sh
@@ -30,16 +30,20 @@ fi
 mkdir -p /mnt/home/unison/.ssh
 
 # copy copied-in /root/importauthkey to enable specific pubkey access for unison user
+# do not replace any existing file at /mnt/home/unison/.ssh/authorized_keys if exists
 if [ -f /root/importauthkey ]; then
-	cp -f /root/importauthkey /mnt/home/unison/.ssh/authorized_keys
+	if [ -f /mnt/home/unison/.ssh/authorized_keys ]; then
+		echo "authorized_keys already exists at the destination. Skipping copy."
+	else
+		cp -f /root/importauthkey /mnt/home/unison/.ssh/authorized_keys
+		# set permissions for .ssh directory and authorized_keys file
+		chmod 700 /mnt/home/unison/.ssh
+		chmod 644 /mnt/home/unison/.ssh/authorized_keys
+		chown -R unison:unison /mnt/home/unison/.ssh
+	fi
 else
 	exit_error "No /root/importauthkey file found"
 fi
-
-# set permissions for .ssh directory and authorized_keys file
-chmod 700 /mnt/home/unison/.ssh
-chmod 644 /mnt/home/unison/.ssh/authorized_keys
-chown -R unison:unison /mnt/home/unison/.ssh
 
 # create a unisondata directory and set permissions
 mkdir -p /mnt/home/unison/unisondata

--- a/unison-ssh/unison-ssh.ini
+++ b/unison-ssh/unison-ssh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="unison-ssh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.0.2"
+version="0.0.3"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
remoter: Don't overwrite authorized_keys if it exists
unison-ssh: Don't overwrite /mnt/home/unison/.ssh/authorized_keys if it exists