### PR TITLE
nomad-server: version bump for rebuild

### DIFF
--- a/nomad-server/CHANGELOG.md
+++ b/nomad-server/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Quote PATH statements
 * Fix consul labels and set IP parameters
 * Switch back to HCL config for consul and test
+* Fix HCL config consul sysrc parameter
 
 ---
 

--- a/nomad-server/nomad-server.d/local/share/cook/bin/configure-consul.sh
+++ b/nomad-server/nomad-server.d/local/share/cook/bin/configure-consul.sh
@@ -57,9 +57,9 @@ chown -R consul:wheel /usr/local/etc/consul.d/
 # enable consul
 service consul enable || true
 
-# set load parameter for consul config
-#sysrc consul_args="-config-file=/usr/local/etc/consul.d/agent.hcl"
-sysrc consul_args="-config-file=/usr/local/etc/consul.d/agent.json"
+# set load parameter for consul config, back to HCL format
+sysrc consul_args="-config-file=/usr/local/etc/consul.d/agent.hcl"
+#sysrc consul_args="-config-file=/usr/local/etc/consul.d/agent.json"
 sysrc consul_syslog_output_priority="warn"
 #sysrc consul_datadir="/var/db/consul"
 #sysrc consul_group="wheel"

--- a/nomad-server/nomad-server.ini
+++ b/nomad-server/nomad-server.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nomad-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="3.25.2"
+version="3.25.3"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
fix consul HCL config sysrc parameter missed in last update