### PR TITLE
Fix Grafana dashboard UIDs and datasources

### DIFF
--- a/grafana/grafana.d/local/share/cook/templates/consulcluster.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/consulcluster.json.in
@@ -2112,7 +2112,7 @@
   },
   "timezone": "",
   "title": "Consul Server Monitoring",
-  "uid": "bebhmiay2e2v4d",
-  "version": 20,
+  "uid": "2Rgdm3pGk",
+  "version": 2,
   "weekStart": ""
 }

--- a/grafana/grafana.d/local/share/cook/templates/consulcluster.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/consulcluster.json.in
@@ -58,7 +58,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -266,7 +266,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -278,7 +278,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -591,7 +591,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -603,7 +603,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -803,7 +803,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -815,7 +815,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -829,7 +829,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -1130,7 +1130,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -1431,7 +1431,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -1443,7 +1443,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -1840,7 +1840,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -1852,7 +1852,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -2078,7 +2078,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -2090,7 +2090,27 @@
   "schemaVersion": 39,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/grafana/grafana.d/local/share/cook/templates/home.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/home.json.in
@@ -102,7 +102,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "000000001"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -116,7 +116,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000001"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -1073,7 +1073,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "000000001"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -1087,7 +1087,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000001"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -2677,7 +2677,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "000000001"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -3700,7 +3700,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000001"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -3712,7 +3712,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "000000001"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -4524,7 +4524,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000001"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -4536,7 +4536,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "000000001"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -4897,7 +4897,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000001"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -4909,7 +4909,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "000000001"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -5151,7 +5151,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000001"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }

--- a/grafana/grafana.d/local/share/cook/templates/home.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/home.json.in
@@ -5272,7 +5272,7 @@
   },
   "timezone": "",
   "title": "Node Exporter FreeBSD",
-  "uid": "Kczn-jPZz",
-  "version": 2,
+  "uid": "abcDef",
+  "version": 5,
   "weekStart": ""
 }

--- a/grafana/grafana.d/local/share/cook/templates/homelogs.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/homelogs.json.in
@@ -221,6 +221,25 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_LOKI",
+        "options": [],
+        "query": "loki",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "loki",

--- a/grafana/grafana.d/local/share/cook/templates/homelogs.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/homelogs.json.in
@@ -285,7 +285,7 @@
   },
   "timezone": "",
   "title": "Search Logs",
-  "uid": "bebhn9098mo74d",
-  "version": 3,
+  "uid": "liz0yRCZz",
+  "version": 4,
   "weekStart": ""
 }

--- a/grafana/grafana.d/local/share/cook/templates/newhomelogs.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/newhomelogs.json.in
@@ -520,7 +520,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Loki - Custom Syslog AIO (All In One)",
-  "uid": "cebhmy01wfcaoe",
-  "version": 2,
+  "uid": "lux4rd0labs_loki_syslog_aio_custom",
+  "version": 4,
   "weekStart": ""
 }

--- a/grafana/grafana.d/local/share/cook/templates/newhomelogs.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/newhomelogs.json.in
@@ -341,6 +341,25 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_LOKI",
+        "options": [],
+        "query": "loki",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
         "current": {},
         "datasource": {
           "type": "loki",

--- a/grafana/grafana.d/local/share/cook/templates/nomadcluster.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/nomadcluster.json.in
@@ -576,7 +576,27 @@
   "schemaVersion": 39,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/grafana/grafana.d/local/share/cook/templates/nomadcluster.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/nomadcluster.json.in
@@ -609,7 +609,7 @@
   },
   "timezone": "",
   "title": "Nomad",
-  "uid": "febhn0whc3v28d",
-  "version": 5,
+  "uid": "dbQ3cS9Zk",
+  "version": 4,
   "weekStart": ""
 }

--- a/grafana/grafana.d/local/share/cook/templates/nomadjobs.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/nomadjobs.json.in
@@ -670,7 +670,7 @@
   },
   "timezone": "",
   "title": "Nomad Allocs",
-  "uid": "aebhn5ddr5czkd",
-  "version": 3,
+  "uid": "ihlUbI9Wk",
+  "version": 12,
   "weekStart": ""
 }

--- a/grafana/grafana.d/local/share/cook/templates/nomadjobs.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/nomadjobs.json.in
@@ -648,7 +648,27 @@
   "schemaVersion": 39,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-15m",

--- a/grafana/grafana.d/local/share/cook/templates/postgres.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/postgres.json.in
@@ -1447,7 +1447,7 @@
   },
   "timezone": "",
   "title": "Postgres Overview",
-  "uid": "wGgaPlciz2",
+  "uid": "wGgaPlciz",
   "version": 6,
   "weekStart": ""
 }

--- a/grafana/grafana.d/local/share/cook/templates/vault.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/vault.json.in
@@ -2759,7 +2759,7 @@
   },
   "timezone": "",
   "title": "Vault",
-  "uid": "bebhnh696wc8we",
-  "version": 16,
+  "uid": "vaults",
+  "version": 3,
   "weekStart": ""
 }

--- a/grafana/grafana.d/local/share/cook/templates/vault.json.in
+++ b/grafana/grafana.d/local/share/cook/templates/vault.json.in
@@ -560,7 +560,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -870,7 +870,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -882,7 +882,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -1136,7 +1136,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -1148,7 +1148,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -1162,7 +1162,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -1967,7 +1967,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -2377,7 +2377,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -2389,7 +2389,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
         "h": 1,
@@ -2633,7 +2633,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${DS_PROMETHEUS}"
           },
           "refId": "A"
         }
@@ -2649,6 +2649,25 @@
   ],
   "templating": {
     "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
       {
         "current": {},
         "datasource": {


### PR DESCRIPTION
With https://github.com/bsdpot/potluck/pull/113 the UIDs of dashboards changed and we kept getting logs flooded every 10s for every dashboard.
```
2025-02-20 08:35:26.442		
logger=provisioning.dashboard type=file name=Potluck t=2025-02-20T08:35:26.442376535Z level=error msg="failed to save dashboard" file=/mnt/grafana/provisioning/dashboards/nomadjobs.json error="could not resolve dashboards:uid:aebhn5ddr5czkd: Dashboard not found"
2025-02-20 08:35:26.438		
logger=provisioning.dashboard type=file name=Potluck t=2025-02-20T08:35:26.438936074Z level=error msg="failed to save dashboard" file=/mnt/grafana/provisioning/dashboards/nomadcluster.json error="could not resolve dashboards:uid:febhn0whc3v28d: Dashboard not found"
2025-02-20 08:35:26.435		
logger=provisioning.dashboard type=file name=Potluck t=2025-02-20T08:35:26.435606759Z level=error msg="failed to save dashboard" file=/mnt/grafana/provisioning/dashboards/newhomelogs.json error="could not resolve dashboards:uid:cebhmy01wfcaoe: Dashboard not found"
```

In this PR I revert to old UIDs and old version+1 (not sure if the version really matters). After Grafana restart the log flooding stopped.

Another thing I noticed was that the datasources changed to `${DS_PROMETHEUS}` and `${DS_LOKI}` but most dashboards didn't have that variable defined so dashboards would have the error `Datasource ${DS_PROMETHEUS} was not found` so I added the variable and replaced some hardcoded datasource UIDs with the var (`consulcluster.json.in` for example, mostly had `${DS_PROMETHEUS}` but also some specific UID for some reason in a few places).
