### PR TITLE
Multiple: Version bump for new base image

### DIFF
--- a/adminer/CHANGELOG.md
+++ b/adminer/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.13
+
+* Version bump for new base image
+
+---
+
 0.12
 
 * Version bump for new base image

--- a/adminer/adminer.ini
+++ b/adminer/adminer.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="adminer"
 author="Deividas Gedgaudas"
-version="0.12.2"
+version="0.13.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/backuppc-nomad/CHANGELOG.md
+++ b/backuppc-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.22
+
+* Version bump for new base image
+
+---
+
 1.21
 
 * Version bump for new base image

--- a/backuppc-nomad/README.md
+++ b/backuppc-nomad/README.md
@@ -64,7 +64,7 @@ job "backuppc" {
       config {
         image = "https://potluck.honeyguide.net/backuppc-nomad"
         pot = "backuppc-nomad-amd64-14_2"
-        tag = "1.21.1"
+        tag = "1.22.1"
         command = "/usr/local/bin/cook"
         args = ["-p","myadminpassword"]
         mount = [

--- a/backuppc-nomad/backuppc-nomad.ini
+++ b/backuppc-nomad/backuppc-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="backuppc-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.21.1"
+version="1.22.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/beast-of-argh/CHANGELOG.md
+++ b/beast-of-argh/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.26
+
+* Version bump for new base image
+
+---
+
 0.25
 
 * Version bump for new base image

--- a/beast-of-argh/beast-of-argh.ini
+++ b/beast-of-argh/beast-of-argh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="beast-of-argh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.25.1"
+version="0.26.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/caddy-s3-nomad/CHANGELOG.md
+++ b/caddy-s3-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.19
+
+* Version bump for new base image
+
+---
+
 0.18
 
 * Version bump for new base image

--- a/caddy-s3-nomad/README.md
+++ b/caddy-s3-nomad/README.md
@@ -100,7 +100,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/caddy-s3-nomad"
         pot = "caddy-s3-nomad-amd64-14_2"
-        tag = "0.18.1"
+        tag = "0.19.1"
         command = "/usr/local/bin/cook"
         args = ["-h","s3.my.host","-b","bucketname","-d","domainname","-e","email@add.com","-s","yes","-x","alertmanager-ip"]
 		mount = [

--- a/caddy-s3-nomad/caddy-s3-nomad.ini
+++ b/caddy-s3-nomad/caddy-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="caddy-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.18.1"
+version="0.19.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/consul/CHANGELOG.md
+++ b/consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.25
+
+* Version bump for new base image
+
+---
+
 2.24
 
 * Version bump for new base image

--- a/consul/consul.ini
+++ b/consul/consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.24.2"
+version="2.25.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/dmarc-report/CHANGELOG.md
+++ b/dmarc-report/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.21
+
+* Version bump for new base image
+
+---
+
 0.20
 
 * Version bump for new base image

--- a/dmarc-report/dmarc-report.ini
+++ b/dmarc-report/dmarc-report.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="dmarc-report"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.20.2"
+version="0.21.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/git-nomad/CHANGELOG.md
+++ b/git-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.24
+
+* Version bump for new base image
+
+---
+
 1.23
 
 * Version bump for new base image

--- a/git-nomad/README.md
+++ b/git-nomad/README.md
@@ -53,7 +53,7 @@ job "examplegit" {
       config {
         image = "https://potluck.honeyguide.net/git-nomad"
         pot = "git-nomad-amd64-14_2"
-        tag = "1.23.1"
+        tag = "1.24.1"
         command = "/usr/local/bin/cook"
         args = ["-n","gitnomad"]
 

--- a/git-nomad/git-nomad.ini
+++ b/git-nomad/git-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="git-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.23.1"
+version="1.24.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/haproxy-minio/CHANGELOG.md
+++ b/haproxy-minio/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.13
+
+* Version bump for new base image
+
+---
+
 0.12
 
 * Version bump for new base image

--- a/haproxy-minio/haproxy-minio.ini
+++ b/haproxy-minio/haproxy-minio.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-minio"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.12.1"
+version="0.13.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/haproxy-sql/CHANGELOG.md
+++ b/haproxy-sql/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.18
+
+* Version bump for new base image
+
+---
+
 0.17
 
 * Version bump for new base image

--- a/haproxy-sql/haproxy-sql.ini
+++ b/haproxy-sql/haproxy-sql.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="haproxy-sql"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.17.1"
+version="0.18.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/hugo-nginx-alt/CHANGELOG.md
+++ b/hugo-nginx-alt/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.13
+
+* Version bump for new base image
+
+---
+
 0.12
 
 * Version bump for new base image

--- a/hugo-nginx-alt/hugo-nginx-alt.ini
+++ b/hugo-nginx-alt/hugo-nginx-alt.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx-alt"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.12.1"
+version="0.13.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/hugo-nginx/CHANGELOG.md
+++ b/hugo-nginx/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.24
+
+* Version bump for new base image
+
+---
+
 0.23
 
 * Version bump for new base image

--- a/hugo-nginx/hugo-nginx.ini
+++ b/hugo-nginx/hugo-nginx.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="hugo-nginx"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.23.1"
+version="0.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/jenkins/CHANGELOG.md
+++ b/jenkins/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.24
+
+* Version bump for new base image
+
+---
+
 0.23
 
 * Version bump for new base image

--- a/jenkins/jenkins.ini
+++ b/jenkins/jenkins.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="jenkins"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.23.1"
+version="0.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mailhub-potluck/CHANGELOG.md
+++ b/mailhub-potluck/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.22
+
+* Version bump for new base image
+
+---
+
 0.21
 
 * Version bump for new base image

--- a/mailhub-potluck/mailhub-potluck.ini
+++ b/mailhub-potluck/mailhub-potluck.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mailhub-potluck"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.21.1"
+version="0.22.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mariadb-galera/CHANGELOG.md
+++ b/mariadb-galera/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.17
+
+* Version bump for new base image
+
+---
+
 0.16
 
 * Version bump for new base image

--- a/mariadb-galera/mariadb-galera.ini
+++ b/mariadb-galera/mariadb-galera.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb-galera"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.16.1"
+version="0.17.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mariadb/CHANGELOG.md
+++ b/mariadb/CHANGELOG.md
@@ -1,3 +1,9 @@
+4.14
+
+* Version bump for new base image
+
+---
+
 4.13
 
 * Version bump for new base image

--- a/mariadb/mariadb.ini
+++ b/mariadb/mariadb.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mariadb"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="4.13.1"
+version="4.14.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/mastodon-s3/CHANGELOG.md
+++ b/mastodon-s3/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.20
+
+* Version bump for new image
+
+---
+
 0.19
 
 * Version bump for new image with pkg 2

--- a/mastodon-s3/mastodon-s3.ini
+++ b/mastodon-s3/mastodon-s3.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="mastodon-s3"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.19.2"
+version="0.20.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/matrix-synapse/CHANGELOG.md
+++ b/matrix-synapse/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.14
+
+* Version bump for new base image
+
+---
+
 2.13
 
 * Version bump for new base image

--- a/matrix-synapse/matrix-synapse.ini
+++ b/matrix-synapse/matrix-synapse.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="matrix-synapse"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.13.1"
+version="2.14.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/netbox/CHANGELOG.md
+++ b/netbox/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.3
+
+* Version bump for new base image
+
+---
+
 0.2
 
 * Version bump for new base image

--- a/netbox/netbox.ini
+++ b/netbox/netbox.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="netbox"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.2.2"
+version="0.3.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nextcloud-nginx-nomad/CHANGELOG.md
+++ b/nextcloud-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.117
+
+* Version bump for new image
+
+---
+
 0.116
 
 * Version bump for new image with pkg 2

--- a/nextcloud-nginx-nomad/README.md
+++ b/nextcloud-nginx-nomad/README.md
@@ -246,7 +246,7 @@ job "nextcloud" {
       config {
         image = "https://potluck.honeyguide.net/nextcloud-nginx-nomad"
         pot = "nextcloud-nginx-nomad-amd64-14_2"
-        tag = "0.116"
+        tag = "0.117"
         command = "/usr/local/bin/cook"
         args = ["-d","/mnt/filestore","-s","host:ip"]
         copy = [

--- a/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
+++ b/nextcloud-nginx-nomad/nextcloud-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.116"
+version="0.117"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nextcloud-spreed-signalling/CHANGELOG.md
+++ b/nextcloud-spreed-signalling/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.7
+
+* Version bump for new base image
+
+---
+
 0.6
 
 * Version bump for new base image

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-spreed-signalling"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.6.1"
+version="0.7.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-nomad-alt/CHANGELOG.md
+++ b/nginx-nomad-alt/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.23
+
+* Version bump for new base image
+
+---
+
 0.22
 
 * Version bump for new base image

--- a/nginx-nomad-alt/README.md
+++ b/nginx-nomad-alt/README.md
@@ -63,7 +63,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-nomad-alt"
         pot = "nginx-nomad-alt-amd64-14_2"
-        tag = "0.22.1"
+        tag = "0.23.1"
         command = "/usr/local/bin/cook"
         args = ["-s","servername"]
         mount = [

--- a/nginx-nomad-alt/nginx-nomad-alt.ini
+++ b/nginx-nomad-alt/nginx-nomad-alt.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-nomad-alt"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.22.1"
+version="0.23.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-rsync-ssh/CHANGELOG.md
+++ b/nginx-rsync-ssh/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.25
+
+* Version bump for new base image
+
+---
+
 0.24
 
 * Version bump for new base image

--- a/nginx-rsync-ssh/nginx-rsync-ssh.ini
+++ b/nginx-rsync-ssh/nginx-rsync-ssh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-rsync-ssh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.24.2"
+version="0.25.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nginx-s3-nomad/CHANGELOG.md
+++ b/nginx-s3-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.25
+
+* Version bump for new base image
+
+---
+
 0.24
 
 * Version bump for new base image

--- a/nginx-s3-nomad/README.md
+++ b/nginx-s3-nomad/README.md
@@ -96,7 +96,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
         pot = "nginx-s3-nomad-amd64-14_2"
-        tag = "0.24.1"
+        tag = "0.25.1"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-x","bucketname","-s","yes"]
         port_map = {
@@ -150,7 +150,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-nomad"
         pot = "nginx-s3-nomad-amd64-14_2"
-        tag = "0.24.1"
+        tag = "0.25.1"
         command = "/usr/local/bin/cook"
         args = ["-a","10.0.0.2","-b","10.0.0.3","-c","10.0.0.4","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-nomad/nginx-s3-nomad.ini
+++ b/nginx-s3-nomad/nginx-s3-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.24.1"
+version="0.25.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-s3-ssl-nomad/CHANGELOG.md
+++ b/nginx-s3-ssl-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.14
+
+* Version bump for new base image
+
+---
+
 0.13
 
 * Version bump for new base image

--- a/nginx-s3-ssl-nomad/README.md
+++ b/nginx-s3-ssl-nomad/README.md
@@ -98,7 +98,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.13.1"
+        tag = "0.14.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -152,7 +152,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.13.1"
+        tag = "0.14.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-x","bucketname","-s","yes"]
         port_map = {
@@ -206,7 +206,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-s3-ssl-nomad"
         pot = "nginx-s3-ssl-nomad-amd64-14_2"
-        tag = "0.13.1"
+        tag = "0.14.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-e","10.0.0.2:9000","-f","10.0.0.3:9000","-g","10.0.0.4:9000","-h","10.0.0.5:9000","-x","bucketname","-s","yes"]
         port_map = {

--- a/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
+++ b/nginx-s3-ssl-nomad/nginx-s3-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-s3-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.13.1"
+version="0.14.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nginx-varnish-ssl-nomad/CHANGELOG.md
+++ b/nginx-varnish-ssl-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.5
+
+* Version bump for new base image
+
+---
+
 0.4
 
 * Version bump for new base image

--- a/nginx-varnish-ssl-nomad/README.md
+++ b/nginx-varnish-ssl-nomad/README.md
@@ -69,7 +69,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/nginx-varnish-ssl-nomad"
         pot = "nginx-varnish-ssl-nomad-amd64-14_2"
-        tag = "0.4.1"
+        tag = "0.5.1"
         command = "/usr/local/bin/cook"
         args = ["-d","domainname","-s","10.0.0.2:8080","-b","bucketname"]
         port_map = {

--- a/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
+++ b/nginx-varnish-ssl-nomad/nginx-varnish-ssl-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nginx-varnish-ssl-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.4.1"
+version="0.5.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/nomad-server/CHANGELOG.md
+++ b/nomad-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.26
+
+* Version bump for new base image
+
+---
+
 3.25
 
 * Version bump for new base image

--- a/nomad-server/nomad-server.ini
+++ b/nomad-server/nomad-server.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nomad-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="3.25.3"
+version="3.26.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/openldap/CHANGELOG.md
+++ b/openldap/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.27
+
+* Version bump for new base image
+
+---
+
 1.26
 
 * Version bump for new base image

--- a/openldap/openldap.ini
+++ b/openldap/openldap.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="openldap"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.26.2"
+version="1.27.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/opensearch/CHANGELOG.md
+++ b/opensearch/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.11
+
+* Version bump for new base image
+
+---
+
 0.10
 
 * Version bump for new base image

--- a/opensearch/opensearch.ini
+++ b/opensearch/opensearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="opensearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.10.3"
+version="0.11.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/postfix-backupmx-nomad/CHANGELOG.md
+++ b/postfix-backupmx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.22
+
+* Version bump for new base image
+
+---
+
 1.21
 
 * Version bump for new base image

--- a/postfix-backupmx-nomad/README.md
+++ b/postfix-backupmx-nomad/README.md
@@ -54,7 +54,7 @@ job "backupmx" {
       config {
         image = "https://potluck.honeyguide.net/postfix-backupmx-nomad"
         pot = "postfix-backupmx-nomad-amd64-14_2"
-        tag = "1.21.1"
+        tag = "1.22.1"
         command = "/usr/local/bin/cook"
         args = ["-n","10.10.10.10/32","-d","'example1.com, example2.com, example.de'","-b","'mx2.example1.com ESMTP \\$mail_name'","-h","mx2.example1.com"]
         mount = [
@@ -117,7 +117,7 @@ job "backupmx" {
        config {
         image = "https://potluck.honeyguide.net/postfix-backupmx-nomad"
         pot = "postfix-backupmx-nomad-amd64-14_2"
-        tag = "1.21.1"
+        tag = "1.22.1"
         command = "/usr/local/bin/cook"
         args = [""]
 

--- a/postfix-backupmx-nomad/postfix-backupmx-nomad.ini
+++ b/postfix-backupmx-nomad/postfix-backupmx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postfix-backupmx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.21.1"
+version="1.22.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/postgres-single/CHANGELOG.md
+++ b/postgres-single/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.16
+
+* Version bump for new base image
+
+---
+
 0.15
 
 * Version bump for new base image

--- a/postgres-single/postgres-single.ini
+++ b/postgres-single/postgres-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="postgres-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.15.1"
+version="0.16.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/rbldnsd/CHANGELOG.md
+++ b/rbldnsd/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.24
+
+* Version bump for new base image
+
+---
+
 0.23
 
 * Version bump for new base image

--- a/rbldnsd/rbldnsd.ini
+++ b/rbldnsd/rbldnsd.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="rbldnsd"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.23.2"
+version="0.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/redis-single/CHANGELOG.md
+++ b/redis-single/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.16
+
+* Version bump for new base image
+
+---
+
 0.15
 
 * Version bump for new base image

--- a/redis-single/redis-single.ini
+++ b/redis-single/redis-single.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="redis-single"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.15.1"
+version="0.16.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/remoter/CHANGELOG.md
+++ b/remoter/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.1
+
+* Version bump for new base image
+
+---
+
 0.0
 
 * Initiate remoter flavour, custom image for internal use

--- a/remoter/remoter.ini
+++ b/remoter/remoter.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="remoter"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.0.6"
+version="0.1.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/saltstack/CHANGELOG.md
+++ b/saltstack/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.24
+
+* Version bump for new base image
+
+---
+
 0.23
 
 * Version bump for new base image

--- a/saltstack/saltstack.ini
+++ b/saltstack/saltstack.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="saltstack"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.23.1"
+version="0.24.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traefik-consul/CHANGELOG.md
+++ b/traefik-consul/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.28
+
+* Version bump for new base image
+
+---
+
 1.27
 
 * Version bump for new base image

--- a/traefik-consul/traefik-consul.ini
+++ b/traefik-consul/traefik-consul.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traefik-consul"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.27.2"
+version="1.28.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/traumadrill/CHANGELOG.md
+++ b/traumadrill/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.26
+
+* Version bump for new base image
+
+---
+
 1.25
 
 * Version bump for new base image

--- a/traumadrill/traumadrill.ini
+++ b/traumadrill/traumadrill.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="traumadrill"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="1.25.1"
+version="1.26.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/unison-ssh/CHANGELOG.md
+++ b/unison-ssh/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.1
+
+* Version bump for new base image
+
+---
+
 0.0
 
 * First bash at unison-ssh jail

--- a/unison-ssh/unison-ssh.ini
+++ b/unison-ssh/unison-ssh.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="unison-ssh"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.0.3"
+version="0.1.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/wordpress-nginx-nomad/CHANGELOG.md
+++ b/wordpress-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.22
+
+* Version bump for new base image
+
+---
+
 2.21
 
 * Version bump for new base image

--- a/wordpress-nginx-nomad/README.md
+++ b/wordpress-nginx-nomad/README.md
@@ -59,7 +59,7 @@ job "example" {
       config {
         image = "https://potluck.honeyguide.net/wordpress-nginx-nomad"
         pot = "wordpress-nginx-nomad-amd64-14_2"
-        tag = "2.21.1"
+        tag = "2.22.1"
         command = "/usr/local/bin/cook"
         args = [""]
         mount = [

--- a/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
+++ b/wordpress-nginx-nomad/wordpress-nginx-nomad.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="wordpress-nginx-nomad"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.21.1"
+version="2.22.1"
 origin="freebsd"
 runs_in_nomad="true"

--- a/zincsearch/CHANGELOG.md
+++ b/zincsearch/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.8
+
+* Version bump for new base image
+
+---
+
 0.7
 
 * Version bump for new base image

--- a/zincsearch/zincsearch.ini
+++ b/zincsearch/zincsearch.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="zincsearch"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.1"
+version="0.8.1"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
Adminer: Version bump for new base image
Backuppc-nomad: Version bump for new base image
Beast-of-argh: Version bump for new base image
Caddy-s3-nomad: Version bump for new base image
Consul: Version bump for new base image
Dmarc-report: Version bump for new base image
Git-nomad: Version bump for new base image
Haproxy-minio: Version bump for new base image
Haproxy-sql: Version bump for new base image
Hugo-nginx: Version bump for new base image
Hugo-nginx-alt: Version bump for new base image
Jenkins: Version bump for new base image
Mailhub-potluck: Version bump for new base image
Mariadb: Version bump for new base image
Mariadb-Galera: Version bump for new base image
Mastodon-s3: Version bump for new image
Matrix-synapse: Version bump for new base image
Netbox: Version bump for new base image
Nextcloud-nginx-nomad: Version bump for new image
Nextcloud-spreed-signalling: Version bump for new base image
Nginx-nomad-alt: Version bump for new base image
Nginx-rsync-ssh: Version bump for new base image
Nginx-s3-nomad: Version bump for new base image
Nginx-s3-ssl-nomad: Version bump for new base image
Nginx-varnish-ssl-nomad: Version bump for new base image
Nomad-server: Version bump for new base image
Openldap: Version bump for new base image
Opensearch: Version bump for new base image
Postfix-backupmx-nomad: Version bump for new base image
Postgres-single: Version bump for new base image
Rbldnsd: Version bump for new base image
Redis-single: Version bump for new base image
Remoter: Version bump for new base image
Saltstack: Version bump for new base image
Traefik-consul: Version bump for new base image
Traumadrill: Version bump for new base image
Unison-ssh: Version bump for new base image
Wordpress-nginx-nomad: Version bump for new base image
Zincsearch: Version bump for new base image