### PR TITLE
nextcloud-nginx-nomad: Version bump for new image

### DIFF
--- a/nextcloud-nginx-nomad/CHANGELOG.md
+++ b/nextcloud-nginx-nomad/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.118
+
+* Version bump for new image
+* Update README for *.config.php to remove trailing commas from final item in arrays
+
+---
+
 0.117
 
 * Version bump for new image

--- a/nextcloud-nginx-nomad/README.md
+++ b/nextcloud-nginx-nomad/README.md
@@ -56,7 +56,7 @@ $AUTOCONFIG = array(
   "dbtableprefix" => 'oc_',
   "adminlogin"    => 'admin name',
   "adminpass"     => 'admin password',
-  "directory"     => '/mnt/filestore',
+  "directory"     => '/mnt/filestore'
 );
 ```
 
@@ -105,7 +105,7 @@ $CONFIG = array (
   'dbtableprefix' => 'oc_',
   'dbuser' => '<db-user>',
   'dbpassword' => '<db-pass>',
-  'mysql.utf8mb4' => true,
+  'mysql.utf8mb4' => true
 );
 ```
 
@@ -125,7 +125,7 @@ $CONFIG = array (
   'dbhost' => '<ip>:<port>',
   'dbtableprefix' => 'oc_',
   'dbuser' => '<db-user>',
-  'dbpassword' => '<db-pass>',
+  'dbpassword' => '<db-pass>'
 );
 ```
 
@@ -151,12 +151,12 @@ $CONFIG = array (
   'trusted_domains' =>
     array (
       0 => '127.0.0.1',
-      1 => '10.0.0.0/8',
+      1 => '10.0.0.0/8'
     ),
   'forwarded_for_headers' =>
     array (
       0 => 'HTTP_X_FORWARDED_FOR',
-      1 => 'HTTP_FORWARDED_FOR',
+      1 => 'HTTP_FORWARDED_FOR'
     ),
 );
 ```
@@ -174,13 +174,13 @@ $CONFIG = array (
     array (
       'path' => '/usr/local/www/nextcloud/apps',
       'url' => '/apps',
-      'writable' => true,
+      'writable' => true
     ),
     1 =>
     array (
       'path' => '/usr/local/www/nextcloud/apps-pkg',
       'url' => '/apps-pkg',
-      'writable' => false,
+      'writable' => false
     ),
   ),
   'logfile' => '/mnt/filestore/nextcloud.log',
@@ -188,14 +188,14 @@ $CONFIG = array (
   'trusted_domains' =>
   array (
     0 => '10.0.0.2',
-    1 => 'my.host.name',
+    1 => 'my.host.name'
   ),
   'datadirectory' => '/mnt/filestore',
   'overwrite.cli.url' => 'https://my.host.name',
   'overwritehost' => 'my.host.name',
   'overwriteprotocol' => 'https',
   'theme' => '',
-  'loglevel' => 0,
+  'loglevel' => 0
 );
 ```
 


### PR DESCRIPTION
Update README for *.config.php to remove trailing commas from final item in arrays.

This was cause of issue where post-install message about CAN_INSTALL file is shown.