### PR TITLE
nextcloud-spreed-signalling: Version bump for new image

### DIFF
--- a/nextcloud-nginx-nomad/README.md
+++ b/nextcloud-nginx-nomad/README.md
@@ -246,7 +246,7 @@ job "nextcloud" {
       config {
         image = "https://potluck.honeyguide.net/nextcloud-nginx-nomad"
         pot = "nextcloud-nginx-nomad-amd64-14_2"
-        tag = "0.117"
+        tag = "0.118"
         command = "/usr/local/bin/cook"
         args = ["-d","/mnt/filestore","-s","host:ip"]
         copy = [

--- a/nextcloud-spreed-signalling/CHANGELOG.md
+++ b/nextcloud-spreed-signalling/CHANGELOG.md
@@ -1,6 +1,8 @@
 0.7
 
 * Version bump for new base image
+* Adjust various services to run on pot IP instead of 127.0.0.1/localhost
+* Update README with steps to configure Nextcloud Talk app
 
 ---
 

--- a/nextcloud-spreed-signalling/README.md
+++ b/nextcloud-spreed-signalling/README.md
@@ -73,4 +73,16 @@ REMOTELOG is an optional parameter for a remote syslog service, such as via the 
 
 ## Usage
 
-tba
+### Configure Nextcloud Talk
+
+From the git repo for the `nextcloud-spreed-signaling` package, https://github.com/strukturag/nextcloud-spreed-signaling
+
+```
+Setup of Nextcloud Talk
+
+Login to your Nextcloud as admin and open the additional settings page. Scroll down to the "Talk" section and enter the base URL of your standalone signaling server in the field "External signaling server". Please note that you have to use https if your Nextcloud is also running on https. Usually you should enter https://myhostname/standalone-signaling as URL.
+
+The value "Shared secret for external signaling server" must be the same as the property secret in section backend of your server.conf.
+
+If you are using a self-signed certificate for development, you need to uncheck the box Validate SSL certificate so backend requests from Nextcloud to the signaling server can be performed.
+```

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/bin/cook
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/bin/cook
@@ -76,19 +76,15 @@ fi
 
 # create hashkey variable
 if [ -z "${HASHKEY+x}" ]; then
-	HASHKEY=$(/usr/bin/openssl rand -base64 16)
-else
-	HASHKEY="$HASHKEY"
+	HASHKEY=$(/usr/bin/openssl rand -base64 32)
 fi
 export HASHKEY
 
+# create blockkey variable
 if [ -z "${BLOCKKEY+x}" ]; then
-	BLOCKKEY=$(/usr/bin/openssl rand -base64 16)
-else
-	BLOCKKEY="$BLOCKKEY"
+	BLOCKKEY=$(/usr/bin/openssl rand -base64 32)
 fi
 export BLOCKKEY
-
 
 ########################################################################
 ## Provision image

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-nats.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-nats.sh
@@ -20,6 +20,7 @@ sep=$'\001'
 
 # copy in custom nats.conf file with 127.0.0.1 instead of localhost
 # IP search/replace does nothing here.
+# Updated: set to use pot IP
 < "$TEMPLATEPATH/nats.conf.in" \
   sed "s${sep}%%ip%%${sep}$IP${sep}g" \
   > /usr/local/etc/nats.conf

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-nginx.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-nginx.sh
@@ -20,7 +20,8 @@ sep=$'\001'
 
 # copy in custom nginx and set IP to ip address of pot image
 < "$TEMPLATEPATH/nginx.conf.in" \
-  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" \
+  sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" | \
+  sed "s${sep}%%ip%%${sep}$IP${sep}g" \
   > /usr/local/etc/nginx/nginx.conf
 
 # make directories

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-ssl.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/bin/configure-ssl.sh
@@ -11,9 +11,6 @@ set -o pipefail
 
 export PATH="/usr/local/bin:$PATH"
 
-DOMAIN="$DOMAIN"
-IP="$IP"
-
 # create directory for local certificates
 mkdir -p /usr/local/etc/ssl/
 

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/nats.conf.in
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/nats.conf.in
@@ -1,3 +1,3 @@
-listen: 127.0.0.1:4222	# host/port to listen for client connections
-http: 127.0.0.1:8222	# HTTP monitoring port
+listen: %%ip%%:4222	# host/port to listen for client connections
+http: %%ip%%:8222	# HTTP monitoring port
 syslog: true

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/nginx.conf.in
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/nginx.conf.in
@@ -19,7 +19,7 @@ http {
 	#access_log  logs/access.log  main;
 
 	upstream signaling {
-		server 127.0.0.1:8080;
+		server %%ip%%:8080;
 	}
 
 	sendfile        on;

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/proxy.conf.in
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/proxy.conf.in
@@ -37,8 +37,8 @@ tokentype = static
 type = janus
 
 # The URL to the websocket endpoint of the MCU server.
-url = ws://127.0.0.1:8188/
-#url = ws://%%ip%%:8188/
+#url = ws://127.0.0.1:8188/
+url = ws://%%ip%%:8188/
 
 # The maximum bitrate per publishing stream (in bits per second).
 # Defaults to 1 mbit/sec.

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/server.conf.in
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/server.conf.in
@@ -1,8 +1,8 @@
 [http]
 # IP and port to listen on for HTTP requests.
 # Comment line to disable the listener.
-listen = 127.0.0.1:8080
-#listen = %%ip%%:8080
+#listen = 127.0.0.1:8080
+listen = %%ip%%:8080
 
 # HTTP socket read timeout in seconds.
 readtimeout = 15
@@ -140,7 +140,7 @@ secret = %%sharedsecret%%
 # multiple backends. For local development, this can be set to "nats://loopback"
 # to process NATS messages internally instead of sending them through an
 # external NATS backend.
-url = nats://127.0.0.1:4222
+url = nats://%%ip%%:4222
 
 [mcu]
 # The type of the MCU to use. Currently only "janus" and "proxy" are supported.
@@ -150,7 +150,7 @@ type = janus
 # For type "janus": the URL to the websocket endpoint of the MCU server.
 # For type "proxy": a space-separated list of proxy URLs to connect to.
 #url =
-url = ws://127.0.0.1:8188/
+url = ws://%%ip%%:8188/
 
 # The maximum bitrate per publishing stream (in bits per second).
 # Defaults to 1 mbit/sec.

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-spreed-signalling"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.1"
+version="0.7.2"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
Adjust various services to run on pot IP instead of 127.0.0.1/localhost

Update README with steps to configure Nextcloud Talk app