### PR TITLE
nextcloud-spreed-signalling: Version bump for rebuild

### DIFF
--- a/nextcloud-spreed-signalling/CHANGELOG.md
+++ b/nextcloud-spreed-signalling/CHANGELOG.md
@@ -3,6 +3,11 @@
 * Version bump for new base image
 * Adjust various services to run on pot IP instead of 127.0.0.1/localhost
 * Update README with steps to configure Nextcloud Talk app
+* Adjust generation of hashkey and blockkey to hex format
+* Add trailing slashes to nginx proxy statements
+* Note that this won't work with current nextcloud because package in ports is too old
+* "Error: Running version: 1.1.3; Server needs to be updated to be compatible with this version of Talk"
+* https://repology.org/project/nextcloud-spreed-signaling/versions
 
 ---
 

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/bin/cook
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/bin/cook
@@ -75,14 +75,16 @@ if [ -n "${CONSULSERVERS+x}" ]; then
 fi
 
 # create hashkey variable
+# The sessions hash key should be 32 or 64 bytes
 if [ -z "${HASHKEY+x}" ]; then
-	HASHKEY=$(/usr/bin/openssl rand -base64 32)
+	HASHKEY=$(/usr/bin/openssl rand -hex 32)
 fi
 export HASHKEY
 
 # create blockkey variable
+# the sessions block key must be 16, 24 or 32 bytes but only 16 below works
 if [ -z "${BLOCKKEY+x}" ]; then
-	BLOCKKEY=$(/usr/bin/openssl rand -base64 32)
+	BLOCKKEY=$(/usr/bin/openssl rand -hex 16)
 fi
 export BLOCKKEY
 

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/nginx.conf.in
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/share/cook/templates/nginx.conf.in
@@ -41,10 +41,6 @@ http {
 		server_name %%domain%%;
 		ssl_certificate /usr/local/etc/ssl/fullchain.cer;
 		ssl_certificate_key /usr/local/etc/ssl/%%domain%%.key;
-		# https://github.com/matrix-org/synapse/blob/develop/docs/reverse_proxy.md
-		# note: do not add a path (even a single /) after the port in `proxy_pass`,
-		# otherwise nginx will canonicalise the URI and cause signature verification
-		# errors.
 
 		root /usr/local/www/spreed;
 		index index.html;
@@ -53,16 +49,18 @@ http {
 			try_files $uri $uri/ =404;
 		}
 
+		# preserve trailing slash on proxy_pass line
 		location /standalone-signaling/ {
-			proxy_pass http://signaling;
+			proxy_pass http://signaling/;
 			proxy_http_version 1.1;
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		}
 
+		# preserve trailing slash on proxy_pass line
 		location /standalone-signaling/spreed {
-			proxy_pass http://signaling/spreed;
+			proxy_pass http://signaling/spreed/;
 			proxy_http_version 1.1;
 			proxy_set_header Upgrade $http_upgrade;
 			proxy_set_header Connection "Upgrade";

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-spreed-signalling"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.2"
+version="0.7.3"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.sh
@@ -128,6 +128,7 @@ pkg install -y node_exporter
 step "Install package nginx"
 pkg install -y nginx
 
+# This is version 1.1.3 which is not compatible with the newer Nextcloud version on ports
 step "Install package nextcloud-spreed-signaling"
 pkg install -y nextcloud-spreed-signaling
 


### PR DESCRIPTION
Adjust generation of hashkey and blockkey to hex format

Add trailing slashes to nginx proxy statements

Note that this won't work with current nextcloud because package in ports is too old

"Error: Running version: 1.1.3; Server needs to be updated to be compatible with this version of Talk"

https://repology.org/project/nextcloud-spreed-signaling/versions