### PR TITLE
Add Nomad proxies to Consul and Vault

### DIFF
--- a/consul-tls/CHANGELOG.md
+++ b/consul-tls/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.8
+
+* Add Nomad proxy
+
+---
+
 0.7
 
 * Version bump for new base image

--- a/consul-tls/consul-tls.d/local/bin/cook
+++ b/consul-tls/consul-tls.d/local/bin/cook
@@ -185,6 +185,15 @@ timeout --foreground 120 \
     service nginx start nodemetricsproxy || true; sleep 3;
   done'
 
+log "Configure nomadproxy"
+configure-nomadproxy.sh
+
+log "Start nomadproxy"
+timeout --foreground 120 \
+  sh -c 'while ! service nginx status nomadproxy; do
+    service nginx start nomadproxy || true; sleep 3;
+  done'
+
 log "Configure consul"
 configure-consul.sh
 

--- a/consul-tls/consul-tls.d/local/share/cook/bin/configure-consul-template.sh
+++ b/consul-tls/consul-tls.d/local/share/cook/bin/configure-consul-template.sh
@@ -24,7 +24,7 @@ chmod 600 \
 echo "s${sep}%%token%%${sep}$TOKEN${sep}" | sed -i '' -f - \
   /usr/local/etc/consul-template.d/consul-template.hcl
 
-for name in vault consul metrics; do
+for name in vault consul metrics nomad; do
     < "$TEMPLATEPATH/$name.tpl.in" \
       sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
       sed "s${sep}%%nodename%%${sep}$NODENAME${sep}g" | \

--- a/consul-tls/consul-tls.d/local/share/cook/bin/configure-nomadproxy.sh
+++ b/consul-tls/consul-tls.d/local/share/cook/bin/configure-nomadproxy.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+## shellcheck disable=SC1091
+#. /root/.env.cook
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+SCRIPT=$(readlink -f "$0")
+TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
+
+# real config dir
+mkdir -p /usr/local/etc/nginx
+
+# shellcheck disable=SC3003
+# safe(r) separator for sed
+#sep=$'\001'
+
+cp "$TEMPLATEPATH/nomadproxy.conf.in" \
+  /usr/local/etc/nginx/nomadproxy.conf
+
+service nginx enable
+sysrc nginx_profiles+="nomadproxy"
+sysrc nginx_nomadproxy_configfile="/usr/local/etc/nginx/nomadproxy.conf"

--- a/consul-tls/consul-tls.d/local/share/cook/templates/consul-template.hcl.in
+++ b/consul-tls/consul-tls.d/local/share/cook/templates/consul-template.hcl.in
@@ -40,3 +40,9 @@ template {
   destination = "/mnt/metricscerts/metrics.checksum"
   command     = "/usr/local/share/cook/bin/reload-metrics.sh"
 }
+
+template {
+  source      = "/mnt/templates/nomad.tpl"
+  destination = "/mnt/nomadcerts/nomad.checksum"
+  command     = "service nginx reload nomadproxy; true"
+}

--- a/consul-tls/consul-tls.d/local/share/cook/templates/nomad.tpl.in
+++ b/consul-tls/consul-tls.d/local/share/cook/templates/nomad.tpl.in
@@ -1,0 +1,16 @@
+{{- $cert:="" }}{{ $key:="" }}
+{{- with secret "nomadpki_int/issue/nomad-client"
+"common_name=%%nodename%%.global.nomad"
+"alt_names=localhost" "ip_sans=127.0.0.1"}}
+{{- $cert = (print .Data.certificate "\n" .Data.issuing_ca) }}
+{{- $key = .Data.private_key }}
+{{- $cert |
+writeToFile "/mnt/nomadcerts/client.crt" "root" "wheel" "0600" "newline"}}
+{{- $key |
+writeToFile "/mnt/nomadcerts/client.key" "root" "wheel" "0600" "newline"}}
+{{- end }}
+{{- with secret "nomadpki/cert/ca" }}
+{{- .Data.certificate |
+writeToFile "/mnt/nomadcerts/ca_root.crt" "root" "wheel" "0644" "newline"}}
+{{- end }}
+{{- (print $cert $key) | sha256Hex }}

--- a/consul-tls/consul-tls.d/local/share/cook/templates/nomadproxy.conf.in
+++ b/consul-tls/consul-tls.d/local/share/cook/templates/nomadproxy.conf.in
@@ -1,0 +1,56 @@
+worker_processes  1;
+error_log  /mnt/log/nomadproxy-error.log;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /usr/local/etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /mnt/log/nomadproxy-access.log  main;
+
+    sendfile        off;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    resolver 127.0.0.1 valid=1s ipv6=off; # aggressive
+
+    server {
+        listen       127.0.0.1:4646 ssl;
+        server_name  localhost;
+
+        ssl_certificate      /mnt/nomadcerts/client.crt;
+        ssl_certificate_key  /mnt/nomadcerts/client.key;
+
+        ssl_protocols TLSv1.3 TLSv1.2;
+        # https://ssl-config.mozilla.org/#server=nginx&config=intermediate
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
+
+        location / {
+          set $nomad_servers nomad.service.consul;
+          proxy_pass https://$nomad_servers:4646;
+          proxy_ssl_certificate /mnt/nomadcerts/client.crt;
+          proxy_ssl_certificate_key /mnt/nomadcerts/client.key;
+          proxy_ssl_verify on;
+          proxy_ssl_trusted_certificate /mnt/nomadcerts/ca_root.crt;
+          proxy_ssl_server_name on;
+          proxy_set_header Host nomad.service.consul;
+        }
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/local/www/nginx-dist;
+        }
+    }
+}

--- a/consul-tls/consul-tls.ini
+++ b/consul-tls/consul-tls.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="consul-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.1"
+version="0.8.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nomad-server-tls/CHANGELOG.md
+++ b/nomad-server-tls/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.16
+
+* Add nomad.service.consul alt name to Nomad certs
+
+---
+
 0.15
 
 * Version bump for new base image

--- a/nomad-server-tls/nomad-server-tls.d/local/share/cook/templates/nomad.tpl.in
+++ b/nomad-server-tls/nomad-server-tls.d/local/share/cook/templates/nomad.tpl.in
@@ -1,7 +1,7 @@
 {{- $cert:="" }}{{ $key:="" }}
 {{- with secret "nomadpki_int/issue/nomad-server"
 "common_name=%%nodename%%.global.nomad"
-"alt_names=localhost,server.global.nomad,metrics.global.nomad"
+"alt_names=localhost,server.global.nomad,metrics.global.nomad,nomad.service.consul"
 "ip_sans=127.0.0.1"}}
 {{- $cert = (print .Data.certificate "\n" .Data.issuing_ca) }}
 {{- $key = .Data.private_key }}

--- a/nomad-server-tls/nomad-server-tls.ini
+++ b/nomad-server-tls/nomad-server-tls.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nomad-server-tls"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.15.1"
+version="0.16.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/vault/CHANGELOG.md
+++ b/vault/CHANGELOG.md
@@ -1,3 +1,11 @@
+2.9
+
+* Add Nomad proxy
+* Allow Nomad PKI to issue server certs for nomad.service.consul
+* Allow Consul and Vault servers to request Nomad client certs
+
+---
+
 2.8
 
 * Version bump for new base image

--- a/vault/vault.d/local/bin/cook
+++ b/vault/vault.d/local/bin/cook
@@ -189,6 +189,9 @@ service consul start
 log "Configure nodemetricsproxy"
 cluster-configure-nodemetricsproxy.sh
 
+log "Configure nomadproxy"
+cluster-configure-nomadproxy.sh
+
 log "Setup node_exporter"
 cluster-configure-node-exporter.sh
 

--- a/vault/vault.d/local/share/cook/bin/cluster-configure-nomadproxy.sh
+++ b/vault/vault.d/local/share/cook/bin/cluster-configure-nomadproxy.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+## shellcheck disable=SC1091
+#. /root/.env.cook
+
+set -e
+# shellcheck disable=SC3040
+set -o pipefail
+
+SCRIPT=$(readlink -f "$0")
+TEMPLATEPATH=$(dirname "$SCRIPT")/../templates
+
+# real config dir
+mkdir -p /usr/local/etc/nginx
+
+# shellcheck disable=SC3003
+# safe(r) separator for sed
+#sep=$'\001'
+
+cp "$TEMPLATEPATH/cluster-nomadproxy.conf.in" \
+  /usr/local/etc/nginx/nomadproxy.conf
+
+service nginx enable
+sysrc nginx_profiles+="nomadproxy"
+sysrc nginx_nomadproxy_configfile="/usr/local/etc/nginx/nomadproxy.conf"

--- a/vault/vault.d/local/share/cook/bin/cluster-init-vault-consul.sh
+++ b/vault/vault.d/local/share/cook/bin/cluster-init-vault-consul.sh
@@ -92,7 +92,7 @@ chmod 600 \
 echo "s${sep}%%token%%${sep}$TOKEN${sep}" | sed -i '' -f - \
   /usr/local/etc/consul-template-consul.d/consul-template-consul.hcl
 
-for name in consul metrics; do
+for name in consul metrics nomad; do
     < "$TEMPLATEPATH/cluster-$name.tpl.in" \
       sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
       sed "s${sep}%%nodename%%${sep}$NODENAME${sep}g" | \
@@ -114,9 +114,16 @@ timeout --foreground 60 \
 echo "s${sep}%%consultoken%%${sep}$VAULT_SERVICE_TOKEN${sep}g" |
   sed -i '' -f - /usr/local/etc/vault.hcl
 
+echo "Start nodemetricsproxy"
 timeout --foreground 120 \
   sh -c 'while ! service nginx status nodemetricsproxy; do
     service nginx start nodemetricsproxy || true; sleep 3;
+  done'
+
+echo "Start nomadproxy"
+timeout --foreground 120 \
+  sh -c 'while ! service nginx status nomadproxy; do
+    service nginx start nomadproxy || true; sleep 3;
   done'
 
 # configure and (re)start syslog-ng if necessary

--- a/vault/vault.d/local/share/cook/bin/cluster-setup-consul-pki.sh
+++ b/vault/vault.d/local/share/cook/bin/cluster-setup-consul-pki.sh
@@ -44,6 +44,7 @@ create_id_group "consul-servers" \
   "issue-consul-server-cert" \
   "issue-metrics-client-cert" \
   "issue-vault-client-cert" \
+  "issue-nomad-client-cert" \
   >/dev/null
 
 

--- a/vault/vault.d/local/share/cook/bin/cluster-setup-nomad-pki.sh
+++ b/vault/vault.d/local/share/cook/bin/cluster-setup-nomad-pki.sh
@@ -35,7 +35,8 @@ create_int_pki "nomadpki" "nomadpki_int" "global.nomad intermediate"
 create_pki_role "nomadpki_int" "nomad-server" \
   "{{identity.entity.metadata.nodename}}.global.nomad" \
   "server.global.nomad" \
-  "metrics.global.nomad"
+  "metrics.global.nomad" \
+  "nomad.service.consul"
 
 vault policy write issue-nomad-server-cert - <<-EOF
 	path "nomadpki_int/issue/nomad-server" {

--- a/vault/vault.d/local/share/cook/bin/cluster-setup-vault-pki.sh
+++ b/vault/vault.d/local/share/cook/bin/cluster-setup-vault-pki.sh
@@ -82,7 +82,10 @@ create_id_entity_alias "$ENTITY_NAME" "$entity_id" "token" \
   'desc="'"$ENTITY_NAME"' alias"' >/dev/null
 
 # Create/update group with entity being the sole member (others will follow)
-create_id_group "vault-servers" "issue-vault-server-cert" >/dev/null
+create_id_group "vault-servers" \
+    "issue-vault-server-cert" \
+    "issue-nomad-client-cert" \
+    >/dev/null
 add_id_group_member "vault-servers" "$entity_id"
 
 # Create token role, which will be applied when issuing

--- a/vault/vault.d/local/share/cook/templates/cluster-consul-template-consul.hcl.in
+++ b/vault/vault.d/local/share/cook/templates/cluster-consul-template-consul.hcl.in
@@ -34,3 +34,9 @@ template {
   destination = "/mnt/metricscerts/metrics.checksum"
   command     = "/usr/local/share/cook/bin/cluster-reload-metrics.sh"
 }
+
+template {
+  source      = "/mnt/templates/nomad.tpl"
+  destination = "/mnt/nomadcerts/nomad.checksum"
+  command     = "service nginx reload nomadproxy; true"
+}

--- a/vault/vault.d/local/share/cook/templates/cluster-nomad.tpl.in
+++ b/vault/vault.d/local/share/cook/templates/cluster-nomad.tpl.in
@@ -1,0 +1,16 @@
+{{- $cert:="" }}{{ $key:="" }}
+{{- with secret "nomadpki_int/issue/nomad-client"
+"common_name=%%nodename%%.global.nomad"
+"alt_names=localhost" "ip_sans=127.0.0.1"}}
+{{- $cert = (print .Data.certificate "\n" .Data.issuing_ca) }}
+{{- $key = .Data.private_key }}
+{{- $cert |
+writeToFile "/mnt/nomadcerts/client.crt" "root" "wheel" "0600" "newline"}}
+{{- $key |
+writeToFile "/mnt/nomadcerts/client.key" "root" "wheel" "0600" "newline"}}
+{{- end }}
+{{- with secret "nomadpki/cert/ca" }}
+{{- .Data.certificate |
+writeToFile "/mnt/nomadcerts/ca_root.crt" "root" "wheel" "0644" "newline"}}
+{{- end }}
+{{- (print $cert $key) | sha256Hex }}

--- a/vault/vault.d/local/share/cook/templates/cluster-nomadproxy.conf.in
+++ b/vault/vault.d/local/share/cook/templates/cluster-nomadproxy.conf.in
@@ -1,0 +1,56 @@
+worker_processes  1;
+error_log  /mnt/log/nomadproxy-error.log;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /usr/local/etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /mnt/log/nomadproxy-access.log  main;
+
+    sendfile        off;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    resolver 127.0.0.1 valid=1s ipv6=off; # aggressive
+
+    server {
+        listen       127.0.0.1:4646 ssl;
+        server_name  localhost;
+
+        ssl_certificate      /mnt/nomadcerts/client.crt;
+        ssl_certificate_key  /mnt/nomadcerts/client.key;
+
+        ssl_protocols TLSv1.3 TLSv1.2;
+        # https://ssl-config.mozilla.org/#server=nginx&config=intermediate
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
+
+        location / {
+          set $nomad_servers nomad.service.consul;
+          proxy_pass https://$nomad_servers:4646;
+          proxy_ssl_certificate /mnt/nomadcerts/client.crt;
+          proxy_ssl_certificate_key /mnt/nomadcerts/client.key;
+          proxy_ssl_verify on;
+          proxy_ssl_trusted_certificate /mnt/nomadcerts/ca_root.crt;
+          proxy_ssl_server_name on;
+          proxy_set_header Host nomad.service.consul;
+        }
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/local/www/nginx-dist;
+        }
+    }
+}

--- a/vault/vault.ini
+++ b/vault/vault.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="vault"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.8.1"
+version="2.9.1"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
Since Nomad 1.7 using Consul/Vault tokens in Nomad agent configuration for Nomad to authenticate to those services is [deprecated](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific#vault-integration-changes) and will be removed in Nomad 1.10. The new way is to use [Workload Identities](https://developer.hashicorp.com/nomad/docs/concepts/workload-identity).

A JWT auth method is used and for that to work Consul and Vault nodes need to be able to reach the Nomad API `/.well-known/jwks.json` so I added a Nomad proxy (identical to other existing proxies, like Vault proxy) to the Consul and Vault nodes.

In the proxy I used the existing Consul DNS record for Nomad `nomad.service.consul`. For that to work I needed to modify the Vault PKI to allow to issue certs for that domain name.

Also, I needed to allow Vault and Consul nodes to request Nomad client certs for the mTLS for the proxy.

I had tested the Nginx, Consul-Template and cert configs to work but I hadn't ran these cook scripts, I hope I added things in the right places and didn't miss anything.