### PR TITLE
nextcloud-spreed-signalling: Version bump for rebuild

### DIFF
--- a/nextcloud-spreed-signalling/CHANGELOG.md
+++ b/nextcloud-spreed-signalling/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.8
+
+* Switch to latest packages
+* New version spreed 2.0.2 in latest pkg stream
+
+---
+
 0.7
 
 * Version bump for new base image

--- a/nextcloud-spreed-signalling/README.md
+++ b/nextcloud-spreed-signalling/README.md
@@ -9,6 +9,8 @@ tags: ["matrix", "synapse", "im", "instant messaging", "rooms", "chat"]
 
 This is a Spreed Signalling server jail that can be started with ```pot```.
 
+This is a non-layered image using latest pkg stream.
+
 The jail exposes parameters that can either be set via the environment.
 
 It also contains `node_exporter` and a local `consul` agent instance to be
@@ -17,7 +19,7 @@ use the [consul](https://potluck.honeyguide.net/blog/consul/) `pot` flavour
 on this site to run `consul`.
 
 # Setup
-You must run this instance from a top level domain such as `signal.yourdomain.com`.
+You must run this instance from a top level domain such as `my.hostname.com`.
 
 ## Installation
 
@@ -63,9 +65,9 @@ The DOMAIN parameter is the domain name to use for `acme.sh` SSL certificate reg
 
 The EMAIL parameter is the email address to use for `acme.sh` SSL certificate registration.
 
-The NEXTCLOUDURL parameter is the FQDN of the Nextcloud instance. Do not include `https://`.
+The NEXTCLOUDURL parameter is the FQDN of the Nextcloud instance. Do not include the `https://` bit, only the FQDN.
 
-The SHAREDSECRET parameter is the shared secret with the Nextcloud instance. This must be 16 or 32 characters.
+The SHAREDSECRET parameter is the shared secret with the Nextcloud instance. This must be 32 characters in hex format.
 
 The PVTCERT parameter will enable self-signed certificates instead of obtaining from provider.
 
@@ -80,7 +82,7 @@ From the git repo for the `nextcloud-spreed-signaling` package, https://github.c
 ```
 Setup of Nextcloud Talk
 
-Login to your Nextcloud as admin and open the additional settings page. Scroll down to the "Talk" section and enter the base URL of your standalone signaling server in the field "External signaling server". Please note that you have to use https if your Nextcloud is also running on https. Usually you should enter https://myhostname/standalone-signaling as URL.
+Login to your Nextcloud as admin and open the additional settings page. Scroll down to the "Talk" section and enter the base URL of your standalone signaling server in the field "External signaling server". Please note that you have to use https if your Nextcloud is also running on https. Usually you should enter https://my.hostname.com/standalone-signaling as URL.
 
 The value "Shared secret for external signaling server" must be the same as the property secret in section backend of your server.conf.
 

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/bin/cook
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.d/local/bin/cook
@@ -68,21 +68,20 @@ done
 
 # Input is "10.0.0.1,10.2.0.1,10.45.2.4"
 # Expected output is "10.0.0.1","10.2.0.1","10.45.2.4"
-
 if [ -n "${CONSULSERVERS+x}" ]; then
     FIXCONSULSERVERS=$(convert_to_required_format "$CONSULSERVERS")
     export FIXCONSULSERVERS
 fi
 
 # create hashkey variable
-# The sessions hash key should be 32 or 64 bytes
+# The sessions hash key should be 32 or 64 bytes but only 32 works in practise
 if [ -z "${HASHKEY+x}" ]; then
 	HASHKEY=$(/usr/bin/openssl rand -hex 32)
 fi
 export HASHKEY
 
 # create blockkey variable
-# the sessions block key must be 16, 24 or 32 bytes but only 16 below works
+# the sessions block key must be 16, 24 or 32 bytes according to docs but only 16 below works in practise
 if [ -z "${BLOCKKEY+x}" ]; then
 	BLOCKKEY=$(/usr/bin/openssl rand -hex 16)
 fi

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="nextcloud-spreed-signalling"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.7.3"
+version="0.8.1"
 origin="freebsd"
 runs_in_nomad="false"

--- a/nextcloud-spreed-signalling/nextcloud-spreed-signalling.sh
+++ b/nextcloud-spreed-signalling/nextcloud-spreed-signalling.sh
@@ -62,9 +62,10 @@ trap 'echo ERROR: $STEP$FAILED | (>&2 tee -a $COOKLOG)' EXIT
 step "Bootstrap package repo"
 mkdir -p /usr/local/etc/pkg/repos
 # only modify repo if not already done in base image
+# switched to latest, change to non-layered image
 # shellcheck disable=SC2016
 test -e /usr/local/etc/pkg/repos/FreeBSD.conf || \
-  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/quarterly" }' \
+  echo 'FreeBSD: { url: "pkg+http://pkg.FreeBSD.org/${ABI}/latest" }' \
     >/usr/local/etc/pkg/repos/FreeBSD.conf
 ASSUME_ALWAYS_YES=yes pkg bootstrap
 
@@ -128,7 +129,7 @@ pkg install -y node_exporter
 step "Install package nginx"
 pkg install -y nginx
 
-# This is version 1.1.3 which is not compatible with the newer Nextcloud version on ports
+# This is version 2.0.2 in latest pkg stream for now
 step "Install package nextcloud-spreed-signaling"
 pkg install -y nextcloud-spreed-signaling
 


### PR DESCRIPTION
Switch to latest packages and non-layered image.

New version spreed 2.0.2 in latest pkg stream.