### PR TITLE
onlyoffice-documentserver: Version bump for rebuild

### DIFF
--- a/onlyoffice-documentserver/CHANGELOG.md
+++ b/onlyoffice-documentserver/CHANGELOG.md
@@ -1,3 +1,9 @@
 0.0
 
 * First bash at a pot jail with onlyoffice-documentserver
+* Fix script which checks if database exists to use greater-than-or-equal because grep is counting 2 items
+* Fix rabbitmq for missing "--node 'name'" option not mentioned in onlyoffice-documentserver pkg info
+* Add missing package py311-setuptools for supervisord
+* Add missing parameter SECRETSTRING to cook script variables check
+* Fix nginx parameter naming variables
+* Update CHECKLIST for python package version name changes

--- a/onlyoffice-documentserver/CHECKLIST.md
+++ b/onlyoffice-documentserver/CHECKLIST.md
@@ -18,5 +18,9 @@ Changes to major or minor versions need to be logged in:
 To force a rebuild of the pot image for the potluck site, increment Z of version="x.y.Z" in:
 * `onlyoffice-documentserver.ini`
 
+## Python version changes
+When python versions change, make sure to update `py311-supervisor` and `py311-setuptools` in
+* `onlyoffice-documentserver.sh`
+
 ## Shellcheck
 Was `shellcheck` run on all applicable shell files?

--- a/onlyoffice-documentserver/onlyoffice-documentserver.d/local/bin/cook
+++ b/onlyoffice-documentserver/onlyoffice-documentserver.d/local/bin/cook
@@ -53,7 +53,7 @@ required_args="DATACENTER IP NODENAME CONSULSERVERS GOSSIPKEY"
 required_args="$required_args DOMAIN EMAIL"
 required_args="$required_args DBHOST DBNAME DBUSER DBPASS"
 optional_args="REMOTELOG DISABLEUNBOUNDV6 RABBITONLYOFFICEPASS"
-optional_args="$optional_args PVTCERT DBPORT"
+optional_args="$optional_args PVTCERT DBPORT SECRETSTRING"
 
 for var in $required_args; do
   if [ -z "$(eval echo "\${$var}")" ]; then

--- a/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/bin/configure-database.sh
+++ b/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/bin/configure-database.sh
@@ -24,8 +24,8 @@ set +o pipefail
 # check if database exists
 dbcheck=$(check_database)
 
-# import database structure if db exists
-if [ "$dbcheck" -eq 1 ]; then
+# import database structure if db exists, using greater-than-or-equal-to operator because grep count is 2 if database exists
+if [ "$dbcheck" -ge 1 ]; then
     echo "Configuring onlyoffice database"
     /usr/local/bin/psql "postgresql://$DBUSER:$DBPASS@$DBHOST:$SETDBPORT/$DBNAME" -f /usr/local/www/onlyoffice/documentserver/server/schema/postgresql/createdb.sql
 else

--- a/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/bin/configure-documentserver.sh
+++ b/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/bin/configure-documentserver.sh
@@ -25,14 +25,14 @@ sep=$'\001'
 
 # copy in custom local.json
 < "$TEMPLATEPATH/local.json.in" \
-  sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
   sed "s${sep}%%dbhost%%${sep}$DBHOST${sep}g" | \
   sed "s${sep}%%dbport%%${sep}$SETDBPORT${sep}g" | \
   sed "s${sep}%%dbname%%${sep}$DBNAME${sep}g" | \
   sed "s${sep}%%dbuser%%${sep}$DBUSER${sep}g" | \
   sed "s${sep}%%dbpass%%${sep}$DBPASS${sep}g" | \
   sed "s${sep}%%verysecretstring%%${sep}$SETSECRETSTRING${sep}g" | \
-  sed "s${sep}%%rabbitonlyofficepass%%${sep}$SETRABBITONLYOFFICEPASS${sep}g" \
+  sed "s${sep}%%rabbitonlyofficepass%%${sep}$SETRABBITONLYOFFICEPASS${sep}g" | \
+  sed "s${sep}%%rabbitnodename%%${sep}$$_POT_NAME${sep}g" \
   > /usr/local/etc/onlyoffice/documentserver/local.json
 
 # unset these for plugin install

--- a/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/bin/configure-nginx.sh
+++ b/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/bin/configure-nginx.sh
@@ -22,7 +22,7 @@ sep=$'\001'
 < "$TEMPLATEPATH/nginx.conf.in" \
   sed "s${sep}%%ip%%${sep}$IP${sep}g" | \
   sed "s${sep}%%domain%%${sep}$DOMAIN${sep}g" | \
-  sed "s${sep}%%verysecretstring%%${sep}$SECRETSTRING${sep}g" \
+  sed "s${sep}%%verysecretstring%%${sep}$SETSECRETSTRING${sep}g" \
   > /usr/local/etc/nginx/nginx.conf
 
 # enable nginx

--- a/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/bin/configure-rabbitmq.sh
+++ b/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/bin/configure-rabbitmq.sh
@@ -30,8 +30,10 @@ service rabbitmq enable
 service rabbitmq start || true
 
 # Create a new rabbitmq user for the ONLYOFFICE Document Server configuration
+# the documentation for the onlyoffice-documentserver port fails to mention including '--node "name"' to make this work
 GETCOOKIE=$(cat /var/db/rabbitmq/.erlang.cookie)
-/usr/local/sbin/rabbitmqctl --erlang-cookie "$GETCOOKIE" add_user onlyoffice "$SETRABBITONLYOFFICEPASS"
-/usr/local/sbin/rabbitmqctl --erlang-cookie "$GETCOOKIE" set_user_tags onlyoffice administrator
-/usr/local/sbin/rabbitmqctl --erlang-cookie "$GETCOOKIE" set_permissions -p / onlyoffice ".*" ".*" ".*"
+GETNODENAME="rabbit@$_POT_NAME"
+/usr/local/sbin/rabbitmqctl --node "$GETNODENAME" --erlang-cookie "$GETCOOKIE" add_user onlyoffice "$SETRABBITONLYOFFICEPASS"
+/usr/local/sbin/rabbitmqctl --node "$GETNODENAME" --erlang-cookie "$GETCOOKIE" set_user_tags onlyoffice administrator
+/usr/local/sbin/rabbitmqctl --node "$GETNODENAME" --erlang-cookie "$GETCOOKIE" set_permissions -p / onlyoffice ".*" ".*" ".*"
 

--- a/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/templates/local.json.in
+++ b/onlyoffice-documentserver/onlyoffice-documentserver.d/local/share/cook/templates/local.json.in
@@ -38,6 +38,6 @@
     }
   },
   "rabbitmq": {
-    "url": "amqp://onlyoffice:%%rabbitonlyofficepass%%@%%ip%%"
+    "url": "amqp://onlyoffice:%%rabbitonlyofficepass%%@%%rabbitnodename%%"
   }
 }

--- a/onlyoffice-documentserver/onlyoffice-documentserver.ini
+++ b/onlyoffice-documentserver/onlyoffice-documentserver.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="onlyoffice-documentserver"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.0.1"
+version="0.0.2"
 origin="freebsd"
 runs_in_nomad="false"

--- a/onlyoffice-documentserver/onlyoffice-documentserver.sh
+++ b/onlyoffice-documentserver/onlyoffice-documentserver.sh
@@ -135,6 +135,13 @@ pkg install -y nginx
 step "Install package python3"
 pkg install -y python3
 
+step "Install package py311-supervisor"
+pkg install -y py311-supervisor
+
+# supervisord needs this but it isn't installed as a dependency with onlyoffice-documentserver
+step "Install package py311-setuptools"
+pkg install -y py311-setuptools
+
 step "Install package postgresql16-client"
 pkg install -y postgresql16-client
 


### PR DESCRIPTION
Fix script which checks if database exists to use greater-than-or-equal because grep is counting 2 items

Fix rabbitmq for missing "--node 'name'" option not mentioned in onlyoffice-documentserver pkg info

Add missing package py311-setuptools for supervisord

Add missing parameter SECRETSTRING to cook script variables check

Fix nginx parameter naming variables

Update CHECKLIST for python package version name changes