### PR TITLE
Fix a few bugs in consul-tls and vault Nomad proxy setup scripts

### DIFF
--- a/consul-tls/CHANGELOG.md
+++ b/consul-tls/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.9
 
 * Make Nomad proxy setup as an optional script
+* Fix a few bugs and notes in setup-nomad-proxy.sh
 
 ---
 

--- a/consul-tls/consul-tls.d/local/share/cook/bin/setup-nomad-proxy.sh
+++ b/consul-tls/consul-tls.d/local/share/cook/bin/setup-nomad-proxy.sh
@@ -2,6 +2,9 @@
 
 # The "consul-servers" Vault group needs the "issue-nomad-client-cert" policy
 # for this to work.
+# Example commands:
+# OLD_POLICIES=$(~/vault.sh read -format=json identity/group/name/consul-servers | jq -c '.data.policies' | tr -d '"[]')
+# ~/vault.sh write identity/group/name/consul-servers policies=${OLD_POLICIES},issue-nomad-client-cert
 
 # shellcheck disable=SC1091
 . /root/.env.cook
@@ -22,11 +25,14 @@ sep=$'\001'
 
 # Copy over consul-template template for Nomad certs
 < "$TEMPLATEPATH/nomad.tpl.in" \
-  sed "s${sep}%%nodename%%${sep}$NODENAME${sep}g" | \
+  sed "s${sep}%%nodename%%${sep}$NODENAME${sep}g" \
   > "/mnt/templates/nomad.tpl"
 
 # Uncomment Nomad cert template in consul-template config
 sed -i '' 's/^##nomadproxy##//g' /usr/local/etc/consul-template.d/consul-template.hcl
+
+# Restart consul-template for it to provision Nomad client certs
+service consul-template restart
 
 # Copy over Nginx config for Nomad proxy
 cp "$TEMPLATEPATH/nomadproxy.conf.in" \

--- a/consul-tls/consul-tls.ini
+++ b/consul-tls/consul-tls.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="consul-server"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="0.9.1"
+version="0.9.2"
 origin="freebsd"
 runs_in_nomad="false"

--- a/vault/CHANGELOG.md
+++ b/vault/CHANGELOG.md
@@ -1,6 +1,7 @@
 2.10
 
 * Make Nomad proxy setup as an optional script
+* Fix a few bugs and notes in cluster-setup-nomad-proxy.sh
 
 ---
 

--- a/vault/vault.ini
+++ b/vault/vault.ini
@@ -1,6 +1,6 @@
 [manifest]
 potname="vault"
 author = "Stephan Lichtenauer, Bretton Vine, Michael Gmelin"
-version="2.10.1"
+version="2.10.2"
 origin="freebsd"
 runs_in_nomad="false"


### PR DESCRIPTION
A few fixes.

Added example commands on how to add the required policy to the Vault groups.

Left a pipe `|` in consul-template template copy over which made the file empty.

Added consul-template restart so it would pull the Nomad certs and Nginx could start.